### PR TITLE
Fix for issue #7 adding "smoothedMeanWithRaw" to value argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# .gitignore
+
+.DS_Store

--- a/R/plots-scatter.R
+++ b/R/plots-scatter.R
@@ -40,20 +40,28 @@ newScatterPD <- function(.dt = data.table::data.table(),
     interval <- groupSmoothedMean(.pd, x, y, group, panel)
     interval <- interval[, !c('ymin', 'ymax')]
     names(interval) <- c('interval.x', 'interval.y', 'interval.se', group, panel)
+    
+    .pd <- interval
+
+  } else if (value == 'smoothedMeanWithRaw') {
+    
+    interval <- groupSmoothedMean(.pd, x, y, group, panel)
+    interval <- interval[, !c('ymin', 'ymax')]
+    names(interval) <- c('interval.x', 'interval.y', 'interval.se', group, panel)
+    
     if (!is.null(key(series))) {
       .pd <- merge(series, interval)
     } else {
       .pd <- cbind(series, interval)
     }
+    
   } else if (value == 'density') {
     density <- groupDensity(.pd, x, group, panel)
     names(density) <- c(group, panel, 'density.x', 'density.y')
-    if (!is.null(key(series))) {
-      .pd <- merge(series, density)
-    } else {
-      .pd <- cbind(series, density)
-    }
+    .pd <- density
+    
   } else {
+    # Return raw data
     .pd <- series
   }
   attr$names <- names(.pd)
@@ -94,7 +102,7 @@ validateScatterPD <- function(.scatter) {
 #' @export
 scattergl.dt <- function(data, 
                          map, 
-                         value = c('smoothedMean', 'density', 'raw')) {
+                         value = c('smoothedMean', 'smoothedMeanWithRaw', 'density', 'raw')) {
   value <- match.arg(value)
 
   overlayVariable = list('variableId' = NULL,
@@ -160,7 +168,7 @@ scattergl.dt <- function(data,
 #' @param value character indicating whether to calculate 'smoothedMean' or 'density' estimates
 #' @return character name of json file containing plot-ready data
 #' @export
-scattergl <- function(data, map, value = c('smoothedMean', 'density', 'raw')) {
+scattergl <- function(data, map, value = c('smoothedMean', 'smoothedMeanWithRaw', 'density', 'raw')) {
   value <- match.arg(value)
   .scatter <- scattergl.dt(data, map, value)
   outFileName <- writeJSON(.scatter, 'scattergl')

--- a/R/plots-scatter.R
+++ b/R/plots-scatter.R
@@ -97,7 +97,7 @@ validateScatterPD <- function(.scatter) {
 #'  density estimates.
 #' @param data data.frame to make plot-ready data for
 #' @param map data.frame with at least two columns (id, plotRef) indicating a variable sourceId and its position in the plot. Recognized plotRef values are 'xAxisVariable', 'yAxisVariable', 'overlayVariable', 'facetVariable1' and 'facetVariable2'
-#' @param value character indicating whether to calculate 'smoothedMean' or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw data with smoothed mean estimates.
+#' @param value character indicating whether to calculate 'smoothedMean' or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw data with smoothed mean
 #' @return data.table plot-ready data
 #' @export
 scattergl.dt <- function(data, 
@@ -165,7 +165,7 @@ scattergl.dt <- function(data,
 #'  density estimates.
 #' @param data data.frame to make plot-ready data for
 #' @param map data.frame with at least two columns (id, plotRef) indicating a variable sourceId and its position in the plot. Recognized plotRef values are 'xAxisVariable', 'yAxisVariable', 'overlayVariable', 'facetVariable1' and 'facetVariable2'
-#' @param value character indicating whether to calculate 'smoothedMean' or 'density' estimates
+#' @param value character indicating whether to calculate 'smoothedMean' or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw data with smoothed mean
 #' @return character name of json file containing plot-ready data
 #' @export
 scattergl <- function(data, map, value = c('smoothedMean', 'smoothedMeanWithRaw', 'density', 'raw')) {

--- a/R/plots-scatter.R
+++ b/R/plots-scatter.R
@@ -97,7 +97,7 @@ validateScatterPD <- function(.scatter) {
 #'  density estimates.
 #' @param data data.frame to make plot-ready data for
 #' @param map data.frame with at least two columns (id, plotRef) indicating a variable sourceId and its position in the plot. Recognized plotRef values are 'xAxisVariable', 'yAxisVariable', 'overlayVariable', 'facetVariable1' and 'facetVariable2'
-#' @param value character indicating whether to calculate 'smoothedMean' or 'density' estimates
+#' @param value character indicating whether to calculate 'smoothedMean' or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw data with smoothed mean estimates.
 #' @return data.table plot-ready data
 #' @export
 scattergl.dt <- function(data, 

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -40,6 +40,11 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('interval.x', 'interval.y', 'interval.se', 'group'))
+  
+  dt <- scattergl.dt(df, map, 'density')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),4)
+  expect_equal(names(dt),c('group', 'density.x', 'density.y'))
 
 
   map <- data.frame('id' = c('y', 'x', 'panel'), 'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1'), 'dataType' = c('NUMBER', 'NUMBER', 'STRING'), stringsAsFactors = FALSE)

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -12,8 +12,17 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   dt <- scattergl.dt(df, map, 'smoothedMean')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),16)
-  expect_equal(names(dt),c('panel', 'group', 'series.y', 'series.x', 'interval.x', 'interval.y', 'interval.se'))
+  expect_equal(names(dt),c('interval.x', 'interval.y', 'interval.se', 'group', 'panel'))
 
+  dt <- scattergl.dt(df, map, 'smoothedMeanWithRaw')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),16)
+  expect_equal(names(dt),c('panel', 'group', 'series.y', 'series.x', 'interval.x', 'interval.y', 'interval.se'))
+  
+  dt <- scattergl.dt(df, map, 'density')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),16)
+  expect_equal(names(dt),c('group', 'panel', 'density.x', 'density.y'))
 
   map <- data.frame('id' = c('group', 'y', 'x'), 'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'), 'dataType' = c('STRING', 'NUMBER', 'NUMBER'), stringsAsFactors = FALSE)
 
@@ -22,10 +31,15 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'series.y', 'series.x'))
 
-  dt <- scattergl.dt(df, map, 'smoothedMean')
+  dt <- scattergl.dt(df, map, 'smoothedMeanWithRaw')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'series.y', 'series.x', 'interval.x', 'interval.y', 'interval.se'))
+  
+  dt <- scattergl.dt(df, map, 'smoothedMean')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),4)
+  expect_equal(names(dt),c('interval.x', 'interval.y', 'interval.se', 'group'))
 
 
   map <- data.frame('id' = c('y', 'x', 'panel'), 'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1'), 'dataType' = c('NUMBER', 'NUMBER', 'STRING'), stringsAsFactors = FALSE)
@@ -35,11 +49,21 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('panel', 'series.y', 'series.x'))
 
-  dt <- scattergl.dt(df, map, 'smoothedMean')
+  dt <- scattergl.dt(df, map, 'smoothedMeanWithRaw')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('panel', 'series.y', 'series.x', 'interval.x', 'interval.y', 'interval.se'))
-
+  
+  dt <- scattergl.dt(df, map, 'smoothedMean')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),4)
+  expect_equal(names(dt),c('interval.x', 'interval.y', 'interval.se', 'panel'))
+  
+  dt <- scattergl.dt(df, map, 'density')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),4)
+  expect_equal(names(dt),c('panel', 'density.x', 'density.y'))
+  
 
   map <- data.frame('id' = c('y', 'x'), 'plotRef' = c('yAxisVariable', 'xAxisVariable'), 'dataType' = c('NUMBER', 'NUMBER'), stringsAsFactors = FALSE)
 
@@ -48,8 +72,18 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(nrow(dt),1)
   expect_equal(names(dt),c('series.y', 'series.x'))
 
-  dt <- scattergl.dt(df, map, 'smoothedMean')
+  dt <- scattergl.dt(df, map, 'smoothedMeanWithRaw')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),1)
   expect_equal(names(dt),c('series.y', 'series.x', 'interval.x', 'interval.y', 'interval.se'))
+  
+  dt <- scattergl.dt(df, map, 'smoothedMean')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),1)
+  expect_equal(names(dt),c('interval.x', 'interval.y', 'interval.se'))
+  
+  dt <- scattergl.dt(df, map, 'density')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),1)
+  expect_equal(names(dt),c('density.x', 'density.y'))
 })


### PR DESCRIPTION
# Fix for issue #7 

Originally the options for the scatterplot value argument were "raw", "density", and "smoothedMean". However, both "density" and "smoothedMean" also returned the raw data. Instead, we want the raw data to only be returned when called for explicitly. 

The proposed fix adds a "smoothMeanWithRaw" option for the scatterplot `value` argument, and removes the raw data from being merged with the smoothedMean interval or density when `value='smoothedMean'` or `='density'`. 


## Testing
The above changes created new, but expected failures in the following test:

```
scattergl.dt() returns an appropriately sized data.table 
```
The new data.tables are missing two columns, which is expected because they no longer contain the raw data. 

Once aligned on the fix and implementation, should we add a test or two for the new argument?

