### PR TITLE
Fix/12/box listvars: allow box plot to accept specified xAxis variables

### DIFF
--- a/R/plots-box.R
+++ b/R/plots-box.R
@@ -129,14 +129,27 @@ box.dt <- function(data, map, points = c('outliers', 'all', 'none'), mean = c(FA
     data <- data.table::as.data.table(data)
   }
   
-  
   #### Currently using a delimiter to know if there are multiple values. Could instead use list. See p.d. issue #5
   if (!identical(independentDelimiter,NULL)) {
 
-    mapDataList <- reshapeByVariableList(data,map,independentDelimiter)
-    map <- mapDataList$map
-    data <- mapDataList$data
-    varOrder <- mapDataList$varOrder
+    # Extract variables from list of variables
+    listedVars <- list('variableId' = unlist(stringr::str_split(map$id[map$plotRef == 'xAxisVariable'], independentDelimiter)),
+                      'entityId' = unlist(stringr::str_split(map$entityId[map$plotRef == 'xAxisVariable'], independentDelimiter)),
+                      'dataType' = unlist(stringr::str_split(map$dataType[map$plotRef == 'xAxisVariable'], independentDelimiter)))
+  
+
+    requiredDataType <- "NUMBER"
+    data <- reshapeByListedVars(data,listedVars, requiredDataType=requiredDataType)
+
+    # Update xAxisVariable in map
+    map$id[map$plotRef == 'xAxisVariable'] = 'variable'
+    map$dataType[map$plotRef == 'xAxisVariable'] = 'STRING'
+    map$entityId[map$plotRef == 'xAxisVariable'] = unique(listedVars$entityId)
+
+    # Add yAxisVariable
+    map <- rbind(map, data.frame('id' = 'value', 'plotRef' = 'yAxisVariable', 'dataType' = requiredDataType))
+
+
     
   } 
 

--- a/R/plots-box.R
+++ b/R/plots-box.R
@@ -152,7 +152,7 @@ box.dt <- function(data, map, points = c('outliers', 'all', 'none'), mean = c(FA
     # entity id?
     map <- rbind(map, data.frame('id' = 'value', 'plotRef' = 'yAxisVariable', 'dataType' = 'NUMBER'))
     
-  } ### At this point, the xAxisVar is a _factor_
+  } ### At this point, the xAxisVar is a _factor_ with the appropriate ordering. What happens?
 
   if ('xAxisVariable' %in% map$plotRef) {
     xAxisVariable <- plotRefMapToList(map, 'xAxisVariable')

--- a/R/plots-box.R
+++ b/R/plots-box.R
@@ -132,6 +132,11 @@ box.dt <- function(data, map, points = c('outliers', 'all', 'none'), mean = c(FA
   #### Currently using a delimiter to know if there are multiple values. Could instead use list. See p.d. issue #5
   if (!identical(independentDelimiter,NULL)) {
 
+    # Stop if the delimiter is not found. Though the rest of the code may not error, such a delimiter is likely a mistake.
+    if (!grepl(independentDelimiter, map$id[map$plotRef == 'xAxisVariable'])){
+      stop(paste0('Delimiter "',independentDelimiter,'" not found in variable list'))
+    }
+
     # Extract variables from list of variables
     listedVars <- list('variableId' = unlist(stringr::str_split(map$id[map$plotRef == 'xAxisVariable'], independentDelimiter)),
                       'entityId' = unlist(stringr::str_split(map$entityId[map$plotRef == 'xAxisVariable'], independentDelimiter)),
@@ -147,7 +152,7 @@ box.dt <- function(data, map, points = c('outliers', 'all', 'none'), mean = c(FA
 
     # Add yAxisVariable
     map <- rbind(map, data.frame('id' = 'value', 'plotRef' = 'yAxisVariable', 'dataType' = requiredDataType))
-    
+
   } 
 
   if ('xAxisVariable' %in% map$plotRef) {

--- a/R/plots-box.R
+++ b/R/plots-box.R
@@ -136,7 +136,6 @@ box.dt <- function(data, map, points = c('outliers', 'all', 'none'), mean = c(FA
     listedVars <- list('variableId' = unlist(stringr::str_split(map$id[map$plotRef == 'xAxisVariable'], independentDelimiter)),
                       'entityId' = unlist(stringr::str_split(map$entityId[map$plotRef == 'xAxisVariable'], independentDelimiter)),
                       'dataType' = unlist(stringr::str_split(map$dataType[map$plotRef == 'xAxisVariable'], independentDelimiter)))
-  
 
     requiredDataType <- "NUMBER"
     data <- reshapeByListedVars(data,listedVars, requiredDataType=requiredDataType)
@@ -148,8 +147,6 @@ box.dt <- function(data, map, points = c('outliers', 'all', 'none'), mean = c(FA
 
     # Add yAxisVariable
     map <- rbind(map, data.frame('id' = 'value', 'plotRef' = 'yAxisVariable', 'dataType' = requiredDataType))
-
-
     
   } 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -245,3 +245,37 @@ findBinEnd <- function(x) {
 
   return(x)
 }
+
+
+reshapeByVariableList <- function(data, map, varDelimiter, plotRefInput='xAxisVariable', plotRefOutput='yAxisVariable', requiredDataType='NUMBER') {
+    
+
+
+    # Extract variables from list of variables
+    orderedVars <- list('variableId' = unlist(stringr::str_split(map$id[map$plotRef == plotRefInput], varDelimiter)),
+                      'entityId' = unlist(stringr::str_split(map$entityId[map$plotRef == plotRefInput], varDelimiter)),
+                      'dataType' = unlist(stringr::str_split(map$dataType[map$plotRef == plotRefInput], varDelimiter)))
+    
+    # Check that all vars are numeric
+    #### Does this have to be numeric in the general case? For boxplots, yes, for heatmaps, yes. Others?
+    if (!identical(unique(orderedVars$dataType), requiredDataType)) {
+      stop(paste0("Any custom input variables must be of data type ",requiredDataType))
+    }
+
+    if (length(unique(orderedVars$entityId)) > 1) {
+      stop("All custom input variables must have the same entityID")
+    }
+
+    ## Now we have a character vector of x axis variables. Reshape to long form
+    data <- data.table::melt(data, measure.vars = orderedVars$variableId, variable.factor = FALSE)
+    
+    # Update xAxisVariable in map
+    map$id[map$plotRef == plotRefInput] = 'variable'
+    map$dataType[map$plotRef == plotRefInput] = 'STRING'
+    map$entityId[map$plotRef == plotRefInput] = unique(orderedVars$entityId)
+
+    # Add yAxisVariable
+    map <- rbind(map, data.frame('id' = 'value', 'plotRef' = plotRefOutput, 'dataType' = requiredDataType))
+
+    return(list('data'=data, 'map'=map, 'varOrder'=orderedVars$variableId))
+}

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -3,59 +3,97 @@ context('box')
 test_that("box.dt() returns an appropriately sized data.table", {
   
   # Ordered box testing - do group and panel, and just y,x
-  map <- data.frame('id' = c('y, x', 'group'),
-                    'plotRef' = c('xAxisVariable', 'overlayVariable'),
-                    'dataType' = c('NUMBER, NUMBER', 'STRING'),
+  map <- data.frame('id' = c('y, x', 'group', 'panel'),
+                    'plotRef' = c('xAxisVariable', 'overlayVariable', 'facetVariable1'),
+                    'dataType' = c('NUMBER, NUMBER', 'STRING', 'STRING'),
                     stringsAsFactors=FALSE)
   df <- data.xy
   dt <- box.dt(df, map, 'none', FALSE, ', ')
   expect_is(dt, 'data.table')
-  expect_equal(nrow(dt), 4)
-  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence'))
-  expect_equal(dt[, variable][[1]], c('x', 'y')) # Check grouping
-  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))  # Check computation on groups
+  expect_equal(nrow(dt), 16)
+  expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence'))
+  # expect_equal(dt[, variable][[1]], c('x', 'y')) # Check grouping was successful
+  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))  # Check computation on groups
   
   dt <- box.dt(df, map, 'none', TRUE, ', ')
   expect_is(dt, 'data.table')
-  expect_equal(nrow(dt), 4)
-  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'mean'))
-  expect_equal(dt[, variable][[1]], c('x', 'y'))
-  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
-  expect_equal(dt[, mean][[1]], c(9.9273, 0.1564)) # Check mean calculation
-  
+  expect_equal(nrow(dt), 16)
+  expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'mean'))
+  # expect_equal(dt[, variable][[1]], c('x', 'y'))
+  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497)) 
+  # expect_equal(dt[, mean][[1]], c(10.1973, 0.3903)) # Check mean calculation
+  # 
   dt <- box.dt(df, map, 'outliers', FALSE, ', ')
   expect_is(dt, 'data.table')
-  expect_equal(nrow(dt), 4)
-  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers'))
-  expect_equal(dt[, variable][[1]], c('x', 'y'))
-  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
-  # expect_equal(dt[, outliers][[3]][[2]], c(2.891384, 2.891384, 2.891384, 2.891384, 2.891384))
+  expect_equal(nrow(dt), 16)
+  expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers'))
+  # expect_equal(dt[, variable][[1]], c('x', 'y'))
+  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))
+  
   
   dt <- box.dt(df, map, 'outliers', TRUE, ', ')
   expect_is(dt, 'data.table')
-  expect_equal(nrow(dt), 4)
-  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers', 'mean'))
-  expect_equal(dt[, variable][[1]], c('x', 'y'))
-  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
-  expect_equal(dt[, mean][[1]], c(9.9273, 0.1564))
-  # expect_equal(dt[, outliers][[3]][[2]], c(2.891384, 2.891384, 2.891384, 2.891384, 2.891384))
+  expect_equal(nrow(dt), 16)
+  expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers', 'mean'))
+  # expect_equal(dt[, variable][[1]], c('x', 'y'))
+  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))
+  # expect_equal(dt[, mean][[1]], c(10.1973, 0.3903))
+  
   
   dt <- box.dt(df, map, 'all', FALSE, ', ')
   expect_is(dt, 'data.table')
-  expect_equal(nrow(dt), 4)
-  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y'))
-  expect_equal(dt[, variable][[1]], c('x', 'y'))
-  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
+  expect_equal(nrow(dt), 16)
+  expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y'))
+  # expect_equal(dt[, variable][[1]], c('x', 'y'))
+  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))
 
   
   dt <- box.dt(df, map, 'all', TRUE, ', ')
   expect_is(dt, 'data.table')
-  expect_equal(nrow(dt), 4)
-  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y', 'mean'))
-  expect_equal(dt[, variable][[1]], c('x', 'y'))
-  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
-  expect_equal(dt[, mean][[1]], c(9.9273, 0.1564))
+  expect_equal(nrow(dt), 16)
+  expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y', 'mean'))
+  # expect_equal(dt[, variable][[1]], c('x', 'y'))
+  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))
+  # expect_equal(dt[, mean][[1]], c(10.1973, 0.3903))
 
+  # Ordered box test using only values for x axis
+  map <- data.frame('id' = c('y, x'),
+                    'plotRef' = c('xAxisVariable'),
+                    'dataType' = c('NUMBER, NUMBER'),
+                    stringsAsFactors = FALSE)
+  
+  dt <- box.dt(df, map, 'none', FALSE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 1)
+  expect_equal(names(dt),c('variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence'))
+  
+  dt <- box.dt(df, map, 'none', TRUE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 1)
+  expect_equal(names(dt),c('variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'mean'))
+  
+  dt <- box.dt(df, map, 'outliers', FALSE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 1)
+  expect_equal(names(dt),c('variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers'))
+  
+  dt <- box.dt(df, map, 'outliers', TRUE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 1)
+  expect_equal(names(dt),c('variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers', 'mean'))
+  
+  dt <- box.dt(df, map, 'all', FALSE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 1)
+  expect_equal(names(dt),c('variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y'))
+  
+  dt <- box.dt(df, map, 'all', TRUE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 1)
+  expect_equal(names(dt),c('variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y', 'mean'))
+  
+  
+  
   
   
   

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -1,6 +1,15 @@
 context('box')
 
 test_that("box.dt() returns an appropriately sized data.table", {
+  
+  # Ordered box testing
+  map <- data.frame('id' = c('x, y'),
+                    'plotRef' = c('xAxisVariable'),
+                    'dataType' = c('NUMBER, NUMBER'),
+                    stringsAsFactors=FALSE)
+  df <- data.xy
+  dt <- box.dt(df, map, 'none', FALSE, ', ')
+  
   #using panel for xaxis.. maybe make another test.dt for this?
   map <- data.frame('id' = c('group', 'y', 'panel'), 'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'), 'dataType' = c('STRING', 'NUMBER', 'STRING'), stringsAsFactors=FALSE)
   df <- data.xy

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -2,7 +2,7 @@ context('box')
 
 test_that("box.dt() returns an appropriately sized data.table", {
   
-  # Ordered box testing
+  # Ordered box testing - do group and panel, and just y,x
   map <- data.frame('id' = c('y, x', 'group'),
                     'plotRef' = c('xAxisVariable', 'overlayVariable'),
                     'dataType' = c('NUMBER, NUMBER', 'STRING'),

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -12,38 +12,85 @@ test_that("box.dt() returns an appropriately sized data.table", {
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt), 4)
   expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence'))
+  expect_equal(dt[, variable][[1]], c('x', 'y')) # Check grouping
+  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))  # Check computation on groups
+  
+  dt <- box.dt(df, map, 'none', TRUE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 4)
+  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'mean'))
   expect_equal(dt[, variable][[1]], c('x', 'y'))
+  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
+  expect_equal(dt[, mean][[1]], c(9.9273, 0.1564)) # Check mean calculation
+  
+  dt <- box.dt(df, map, 'outliers', FALSE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 4)
+  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers'))
+  expect_equal(dt[, variable][[1]], c('x', 'y'))
+  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
+  # expect_equal(dt[, outliers][[3]][[2]], c(2.891384, 2.891384, 2.891384, 2.891384, 2.891384))
+  
+  dt <- box.dt(df, map, 'outliers', TRUE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 4)
+  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers', 'mean'))
+  expect_equal(dt[, variable][[1]], c('x', 'y'))
+  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
+  expect_equal(dt[, mean][[1]], c(9.9273, 0.1564))
+  # expect_equal(dt[, outliers][[3]][[2]], c(2.891384, 2.891384, 2.891384, 2.891384, 2.891384))
+  
+  dt <- box.dt(df, map, 'all', FALSE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 4)
+  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y'))
+  expect_equal(dt[, variable][[1]], c('x', 'y'))
+  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
+
+  
+  dt <- box.dt(df, map, 'all', TRUE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 4)
+  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y', 'mean'))
+  expect_equal(dt[, variable][[1]], c('x', 'y'))
+  expect_equal(dt[, median][[1]], c(10.1057,  0.1214))
+  expect_equal(dt[, mean][[1]], c(9.9273, 0.1564))
+
+  
+  
+  
+  
   
   #using panel for xaxis.. maybe make another test.dt for this?
   map <- data.frame('id' = c('group', 'y', 'panel'), 'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'), 'dataType' = c('STRING', 'NUMBER', 'STRING'), stringsAsFactors=FALSE)
   df <- data.xy
 
-  dt <- box.dt(df, map, 'none', FALSE)
+  dt <- box.dt(df, map, 'none', FALSE, independentDelimiter=NULL)
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'panel', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence'))
 
-  dt <- box.dt(df, map, 'none', TRUE)
+  dt <- box.dt(df, map, 'none', TRUE, independentDelimiter=NULL)
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'panel', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'mean'))
 
-  dt <- box.dt(df, map, 'outliers', FALSE)
+  dt <- box.dt(df, map, 'outliers', FALSE, independentDelimiter=NULL)
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'panel', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers'))
 
-  dt <- box.dt(df, map, 'outliers', TRUE)
+  dt <- box.dt(df, map, 'outliers', TRUE, independentDelimiter=NULL)
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'panel', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers', 'mean'))
 
-  dt <- box.dt(df, map, 'all', FALSE)
+  dt <- box.dt(df, map, 'all', FALSE, independentDelimiter=NULL)
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'panel', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y'))
 
-  dt <- box.dt(df, map, 'all', TRUE)
+  dt <- box.dt(df, map, 'all', TRUE, independentDelimiter=NULL)
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'panel', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y', 'mean'))

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -12,49 +12,31 @@ test_that("box.dt() returns an appropriately sized data.table", {
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt), 16)
   expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence'))
-  # expect_equal(dt[, variable][[1]], c('x', 'y')) # Check grouping was successful
-  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))  # Check computation on groups
-  
+
   dt <- box.dt(df, map, 'none', TRUE, ', ')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt), 16)
   expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'mean'))
-  # expect_equal(dt[, variable][[1]], c('x', 'y'))
-  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497)) 
-  # expect_equal(dt[, mean][[1]], c(10.1973, 0.3903)) # Check mean calculation
-  # 
+
   dt <- box.dt(df, map, 'outliers', FALSE, ', ')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt), 16)
   expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers'))
-  # expect_equal(dt[, variable][[1]], c('x', 'y'))
-  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))
-  
   
   dt <- box.dt(df, map, 'outliers', TRUE, ', ')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt), 16)
   expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers', 'mean'))
-  # expect_equal(dt[, variable][[1]], c('x', 'y'))
-  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))
-  # expect_equal(dt[, mean][[1]], c(10.1973, 0.3903))
-  
   
   dt <- box.dt(df, map, 'all', FALSE, ', ')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt), 16)
   expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y'))
-  # expect_equal(dt[, variable][[1]], c('x', 'y'))
-  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))
-
   
   dt <- box.dt(df, map, 'all', TRUE, ', ')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt), 16)
   expect_equal(names(dt),c('panel', 'group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y', 'mean'))
-  # expect_equal(dt[, variable][[1]], c('x', 'y'))
-  # expect_equal(dt[, median][[1]], c(10.2469,  0.3497))
-  # expect_equal(dt[, mean][[1]], c(10.1973, 0.3903))
 
   # Ordered box test using only values for x axis
   map <- data.frame('id' = c('y, x'),
@@ -91,11 +73,6 @@ test_that("box.dt() returns an appropriately sized data.table", {
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt), 1)
   expect_equal(names(dt),c('variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'series.x', 'series.y', 'mean'))
-  
-  
-  
-  
-  
   
   
   

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -3,12 +3,16 @@ context('box')
 test_that("box.dt() returns an appropriately sized data.table", {
   
   # Ordered box testing
-  map <- data.frame('id' = c('x, y'),
-                    'plotRef' = c('xAxisVariable'),
-                    'dataType' = c('NUMBER, NUMBER'),
+  map <- data.frame('id' = c('y, x', 'group'),
+                    'plotRef' = c('xAxisVariable', 'overlayVariable'),
+                    'dataType' = c('NUMBER, NUMBER', 'STRING'),
                     stringsAsFactors=FALSE)
   df <- data.xy
   dt <- box.dt(df, map, 'none', FALSE, ', ')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 4)
+  expect_equal(names(dt),c('group', 'variable', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence'))
+  expect_equal(dt[, variable][[1]], c('x', 'y'))
   
   #using panel for xaxis.. maybe make another test.dt for this?
   map <- data.frame('id' = c('group', 'y', 'panel'), 'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'), 'dataType' = c('STRING', 'NUMBER', 'STRING'), stringsAsFactors=FALSE)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -78,3 +78,15 @@ test_that("contingencyDT() returns appropriately sized data.table", {
   expect_equal(nrow(dt),data.table::uniqueN(data.binned$x))
   expect_equal(length(dt),data.table::uniqueN(data.binned$y)+1)
 })
+
+test_that("reshapeByListedVars() returns appropriately sized data.table for numeric vars", {
+  listedVars <- list('variableId' = c('x'), 'entityId' = NULL, 'dataType' = c('NUMBER'))
+  dt <- reshapeByListedVars(bigData.xy, listedVars, 'NUMBER')
+  expect_equal(nrow(dt), nrow(bigData.xy))
+  expect_true(all(c('variable','value') %in% names(dt)))
+  
+  listedVars <- list('variableId' = c('y', 'x'), 'entityId' = NULL, 'dataType' = c('NUMBER', 'NUMBER'))
+  dt <- reshapeByListedVars(bigData.xy, listedVars, 'NUMBER')
+  expect_equal(nrow(dt), 2*nrow(bigData.xy))
+  expect_true(all(c('variable','value') %in% names(dt)))
+})


### PR DESCRIPTION
# Fix for issue #12 

Goal: Allow allow one to specify an arbitrary list of numeric columns in the data to be used as x-axis values (i.e. one box per column).

The main update with this code is a function called `reshapeByListedVars`, which takes in the data table, an appropriate list of variables, and expected variable type, and melts the data from wide to long based on these variables. The function itself really just wraps data.table::melt, but adds extra checks to ensure we're using appropriate variables.

Currently, we have a passable solution but I would like to improve it. Before , we should discuss the following:
1. How should multiple variables get encoded into `map`? Worth thinking about in tandem with issue #5. Currently we let "xAxisVariable" elements in `map` be strings that get split by a specified delimiter. Alternatively, we could let "plotRef" hold multiple "xAxisVariable"s, and we can simply check to see if there is more than one "xAxisVariable". Currently we use the former because it feels less likely for the variable ordering to get mixed up. Though the latter would remove the need for a delimiter so that's very attractive...
2. When and how to set the `varOrder` attribute? Ideally we set this inside `newBoxPD`. I am considering the following
     - Get `varOrder` from the original `map` passed to `box.dt`. Easy to do but we have to alter `map` before it is sent to `newBoxPD` and this alteration removes the variable ordering information. So, we would have to send the info to `newBoxPD` through a new function argument.
     - Get `varOrder` from the levels of the reshaped data.table. If we use `data.table::melt`, then we have the option to set the new `variable` column in the output data.table to be factors with the appropriate ordered levels. If we go this route, then when we send data to `newBoxPD`, inside that function we can use `levels()` to extract the ordering information, and set the attribute right there in `newBoxPD`. That's great, but it means we are relying on data columns being factors in certain cases and not others, and we don't have factors elsewhere so this option feels not so robust. <br>
     
For now I'll choose the first of passing the variable order information as a new argument to `newBoxPD`.

3. The "custom input variable" language could use some help. Picked variables? 
4. When Dave returns, I'll ping him about the new attribute coming his way.


Considering renaming `reshapeByListedVars` to `reshapeByVarList`. Hmm.

## Testing
Added new unit tests for `box.dt` and for `reshapeByListedVars` (in utils.R).

## Profiling
todo.