### PR TITLE
Fix/23/ as.data.table to setDT

### DIFF
--- a/R/class-plotdata-bar.R
+++ b/R/class-plotdata-bar.R
@@ -80,7 +80,6 @@ bar.dt <- function(data, map, value = c('count', 'identity')) {
                         'dataType' = NULL)
 
   if (!'data.table' %in% class(data)) {
-    # data <- data.table::as.data.table(data)
     data.table::setDT(data)
   }
 

--- a/R/class-plotdata-bar.R
+++ b/R/class-plotdata-bar.R
@@ -80,7 +80,8 @@ bar.dt <- function(data, map, value = c('count', 'identity')) {
                         'dataType' = NULL)
 
   if (!'data.table' %in% class(data)) {
-    data <- data.table::as.data.table(data)
+    # data <- data.table::as.data.table(data)
+    data.table::setDT(data)
   }
 
   if ('xAxisVariable' %in% map$plotRef) {

--- a/R/class-plotdata-box.R
+++ b/R/class-plotdata-box.R
@@ -124,7 +124,8 @@ box.dt <- function(data, map, points = c('outliers', 'all', 'none'), mean = c(FA
                         'dataType' = NULL)
 
   if (!'data.table' %in% class(data)) {
-    data <- data.table::as.data.table(data)
+    # data <- data.table::as.data.table(data)
+    data.table::setDT(data)
   }
 
   if ('xAxisVariable' %in% map$plotRef) {

--- a/R/class-plotdata-box.R
+++ b/R/class-plotdata-box.R
@@ -124,7 +124,6 @@ box.dt <- function(data, map, points = c('outliers', 'all', 'none'), mean = c(FA
                         'dataType' = NULL)
 
   if (!'data.table' %in% class(data)) {
-    # data <- data.table::as.data.table(data)
     data.table::setDT(data)
   }
 

--- a/R/class-plotdata-heatmap.R
+++ b/R/class-plotdata-heatmap.R
@@ -100,7 +100,8 @@ heatmap.dt <- function(data, map, value = c('series', 'collection')) {
                         'dataType' = NULL) 
 
   if (!'data.table' %in% class(data)) {
-    data <- data.table::as.data.table(data)
+    # data <- data.table::as.data.table(data)
+    data.table::setDT(data)
   }
 
   if ('xAxisVariable' %in% map$plotRef) {

--- a/R/class-plotdata-heatmap.R
+++ b/R/class-plotdata-heatmap.R
@@ -100,7 +100,6 @@ heatmap.dt <- function(data, map, value = c('series', 'collection')) {
                         'dataType' = NULL) 
 
   if (!'data.table' %in% class(data)) {
-    # data <- data.table::as.data.table(data)
     data.table::setDT(data)
   }
 

--- a/R/class-plotdata-histogram.R
+++ b/R/class-plotdata-histogram.R
@@ -216,7 +216,8 @@ histogram.dt <- function(data,
   binReportValue <- match.arg(binReportValue)
 
   if (!'data.table' %in% class(data)) {
-    data <- data.table::as.data.table(data)
+    # data <- data.table::as.data.table(data)
+    data.table::setDT(data)
   }
 
   if ('xAxisVariable' %in% map$plotRef) {

--- a/R/class-plotdata-histogram.R
+++ b/R/class-plotdata-histogram.R
@@ -216,7 +216,6 @@ histogram.dt <- function(data,
   binReportValue <- match.arg(binReportValue)
 
   if (!'data.table' %in% class(data)) {
-    # data <- data.table::as.data.table(data)
     data.table::setDT(data)
   }
 

--- a/R/class-plotdata-mosaic.R
+++ b/R/class-plotdata-mosaic.R
@@ -89,7 +89,6 @@ mosaic.dt <- function(data, map) {
                         'dataType' = NULL)
 
   if (!'data.table' %in% class(data)) {
-    # data <- data.table::as.data.table(data)
     data.table::setDT(data)
   }
 

--- a/R/class-plotdata-mosaic.R
+++ b/R/class-plotdata-mosaic.R
@@ -89,7 +89,8 @@ mosaic.dt <- function(data, map) {
                         'dataType' = NULL)
 
   if (!'data.table' %in% class(data)) {
-    data <- data.table::as.data.table(data)
+    # data <- data.table::as.data.table(data)
+    data.table::setDT(data)
   }
 
   if ('xAxisVariable' %in% map$plotRef) {

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -119,7 +119,8 @@ scattergl.dt <- function(data,
                         'dataType' = NULL)
 
   if (!'data.table' %in% class(data)) {
-    data <- data.table::as.data.table(data)
+    # data <- data.table::as.data.table(data)
+    data.table::setDT(data)
   }
 
   if ('xAxisVariable' %in% map$plotRef) {

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -119,7 +119,6 @@ scattergl.dt <- function(data,
                         'dataType' = NULL)
 
   if (!'data.table' %in% class(data)) {
-    # data <- data.table::as.data.table(data)
     data.table::setDT(data)
   }
 

--- a/R/utils-stats.R
+++ b/R/utils-stats.R
@@ -242,7 +242,7 @@ bothRatios <- function(data, collapse = TRUE) {
 chiSq <- function(data, collapse = TRUE) {
   tbl <- table(data$x, data$y)
   dt <- as.data.frame.matrix(tbl)
-  dt <- data.table::as.data.table(dt)
+  data.table::setDT(dt)
   dt[, value := lapply(transpose(.SD), as.vector)]
   dt$yLabel <- list(names(dt)[names(dt) != 'value'])
   dt$xLabel <- rownames(tbl)

--- a/R/utils.R
+++ b/R/utils.R
@@ -85,7 +85,7 @@ contingencyDT <- function(data, labels = TRUE) {
     dt$label <- rownames(dt)
   }
 
-  return(data.table::as.data.table(dt))
+  return(data.table::setDT(dt))
 }
 
 findPanelColName <- function(facet1 = NULL, facet2 = NULL) {


### PR DESCRIPTION
# Fix for issue #23 

This PR replaces `data.table::as.data.table` with `data.table::setDT` in the following contexts:
- `class-plotdata-*.R`
- `utils.R`
- `utils-stats.R` function `chiSq`.

The other uses of `data.table::as.data.table` (found in `utils-stats.R` and `group.R`) were not changed because they often have a matrix or vector passed as input. `data.table::as.data.table` can handle such inputs but `setDT` requires the input to be a list, data.frame, or data.table.


