### PR TITLE
Feature/28/bar to take proportion

### DIFF
--- a/R/class-plotdata-bar.R
+++ b/R/class-plotdata-bar.R
@@ -29,12 +29,16 @@ newBarPD <- function(.dt = data.table::data.table(),
   panel <- findPanelColName(attr$facetVariable1$variableId, attr$facetVariable2$variableId)
 
   if (value == 'identity') {
-    .pd <- collapseByGroup(.pd, group, panel)
+    pd1 <- collapseByGroup(.pd, group, panel)
   } else if (value == 'count' ) {
     .pd$dummy <- 1
-    .pd <- groupSize(.pd, x, 'dummy', group, panel, collapse = T)
+    pd2 <- groupSize(.pd, x, 'dummy', group, panel, collapse = T)
     data.table::setnames(.pd, c(group, panel, 'label', 'value'))
 
+  } else if (value == 'proportion') {
+    .pd$dummy <- 1
+    .pd <- groupProportion(.pd, x, 'dummy', group, panel, collapse = T)
+    data.table::setnames(.pd, c(group, panel, 'label', 'proportion')) #### Last may be value
   }
   attr$names <- names(.pd)
   

--- a/R/class-plotdata-bar.R
+++ b/R/class-plotdata-bar.R
@@ -110,7 +110,7 @@ bar.dt <- function(data, map, value = c('count', 'identity', 'proportion')) {
                     facetVariable2 = facetVariable2,
                     value)
 
-  #.bar <- validateBarPD(.bar)
+  .bar <- validateBarPD(.bar)
 
   return(.bar)
 }

--- a/R/class-plotdata-bar.R
+++ b/R/class-plotdata-bar.R
@@ -29,16 +29,16 @@ newBarPD <- function(.dt = data.table::data.table(),
   panel <- findPanelColName(attr$facetVariable1$variableId, attr$facetVariable2$variableId)
 
   if (value == 'identity') {
-    pd1 <- collapseByGroup(.pd, group, panel)
+    .pd <- collapseByGroup(.pd, group, panel)
   } else if (value == 'count' ) {
     .pd$dummy <- 1
-    pd2 <- groupSize(.pd, x, 'dummy', group, panel, collapse = T)
+    .pd <- groupSize(.pd, x, 'dummy', group, panel, collapse = T)
     data.table::setnames(.pd, c(group, panel, 'label', 'value'))
 
   } else if (value == 'proportion') {
     .pd$dummy <- 1
     .pd <- groupProportion(.pd, x, 'dummy', group, panel, collapse = T)
-    data.table::setnames(.pd, c(group, panel, 'label', 'proportion')) #### Last may be value
+    data.table::setnames(.pd, c(group, panel, 'label', 'value'))
   }
   attr$names <- names(.pd)
   
@@ -70,7 +70,7 @@ validateBarPD <- function(.bar) {
 #' @param value String indicating how to calculate y-values ('identity', 'count')
 #' @return data.table plot-ready data
 #' @export
-bar.dt <- function(data, map, value = c('count', 'identity')) {
+bar.dt <- function(data, map, value = c('count', 'identity', 'proportion')) {
   value <- match.arg(value)
 
   overlayVariable = list('variableId' = NULL,
@@ -128,7 +128,7 @@ bar.dt <- function(data, map, value = c('count', 'identity')) {
 #' @param value String indicating how to calculate y-values ('identity', 'count')
 #' @return character name of json file containing plot-ready data
 #' @export
-bar <- function(data, map, value = c('count', 'identity')) {
+bar <- function(data, map, value = c('count', 'identity', 'proportion')) {
   value <- match.arg(value)
   .bar <- bar.dt(data, map, value)
   outFileName <- writeJSON(.bar, 'barplot')

--- a/R/class-plotdata-bar.R
+++ b/R/class-plotdata-bar.R
@@ -62,12 +62,13 @@ validateBarPD <- function(.bar) {
 #' plot-ready data with one row per group (per panel). Columns 
 #' 'label' and 'value' contain the raw data for plotting. Column 
 #' 'group' and 'panel' specify the group the series data belongs to.
-#' There are two options to calculate y-values for plotting.
+#' There are three options to calculate y-values for plotting.
 #' 1) raw 'identity' of values from data.table input
-#' 2) 'count' occurances of values from data.table input 
+#' 2) 'count' occurrences of values from data.table input 
+#' 3) 'proportion' of occurrences of values from data.table input 
 #' @param data data.frame to make plot-ready data for
 #' @param map data.frame with at least two columns (id, plotRef) indicating a variable sourceId and its position in the plot. Recognized plotRef values are 'xAxisVariable', 'overlayVariable', 'facetVariable1' and 'facetVariable2'
-#' @param value String indicating how to calculate y-values ('identity', 'count')
+#' @param value String indicating how to calculate y-values ('identity', 'count', 'proportion')
 #' @return data.table plot-ready data
 #' @export
 bar.dt <- function(data, map, value = c('count', 'identity', 'proportion')) {
@@ -120,12 +121,13 @@ bar.dt <- function(data, map, value = c('count', 'identity', 'proportion')) {
 #' plot-ready data with one row per group (per panel). Columns 
 #' 'label' and 'value' contain the raw data for plotting. Column 
 #' 'group' and 'panel' specify the group the series data belongs to.
-#' There are two options to calculate y-values for plotting.
+#' There are three options to calculate y-values for plotting.
 #' 1) raw 'identity' of values from data.table input
-#' 2) 'count' occurances of values from data.table input 
+#' 2) 'count' occurrences of values from data.table input 
+#' 3) 'proportion' of occurrences of values from data.table input 
 #' @param data data.frame to make plot-ready data for
 #' @param map data.frame with at least two columns (id, plotRef) indicating a variable sourceId and its position in the plot. Recognized plotRef values are 'xAxisVariable', 'overlayVariable', 'facetVariable1' and 'facetVariable2'
-#' @param value String indicating how to calculate y-values ('identity', 'count')
+#' @param value String indicating how to calculate y-values ('identity', 'count', 'proportion')
 #' @return character name of json file containing plot-ready data
 #' @export
 bar <- function(data, map, value = c('count', 'identity', 'proportion')) {

--- a/R/group.R
+++ b/R/group.R
@@ -87,6 +87,44 @@ groupSize <- function(data, x = NULL, y, group = NULL, panel = NULL, collapse=T)
   return(dt)
 }
 
+
+groupProportion <- function(data, x = NULL, y, group = NULL, panel = NULL, collapse=T) {
+  aggStr <- getAggStr(y, c(x, group, panel))
+  
+  if (aggStr == y) {
+    # dt <- data.table::as.data.table(t(length(data[[y]])))
+    dt <- data.table::as.data.table(t(1)) #### Without grouping proportion should always be 1
+  } else {
+    dt <- data.table::as.data.table(aggregate(as.formula(aggStr), .pd, length))
+    # dtb <- data.table::as.data.table(aggregate(as.formula(aggStr), .pd, length))
+    neededCols <- c(group, panel)
+    # dtc <- dtb[, sum := sum(dummy), by=neededCols][, prop := dummy/sum]
+    dt[, sum := sum(get(y)), by=neededCols][, prop := get(y)/sum]
+    
+    # Remove unnecessary columns
+    dt[, sum := NULL]
+    dt[, (y) := NULL]
+    
+    # myy <- c(y)
+    # dtb <- dta[, sum := ..myy]
+  }
+  
+  data.table::setnames(dt, c(x, group, panel, 'proportion'))
+  indexCols <- c(panel, group)
+  setkeyv(dt, indexCols)
+  
+  if (collapse) {
+    dt <- collapseByGroup(dt, group, panel)
+  }
+  
+  return(dt)
+}
+
+proportion <- function(x) {
+  sum(x)/length(x)
+}
+
+
 groupOutliers <- function(data, x = NULL, y, group = NULL, panel = NULL, collapse=T) {
   aggStr <- getAggStr(y, c(x, group, panel))
 

--- a/R/group.R
+++ b/R/group.R
@@ -92,7 +92,7 @@ groupProportion <- function(data, x = NULL, y, group = NULL, panel = NULL, colla
   aggStr <- getAggStr(y, c(x, group, panel))
   
   if (aggStr == y) {
-    dt <- data.table::as.data.table(t(1)) # Without any grouping, proportion should always be 1
+    dt <- data.table::as.data.table(t(1)) # Without any grouping, proportion should always = 1
   } else {
 
     # Aggregate to get counts of value per group

--- a/R/group.R
+++ b/R/group.R
@@ -95,14 +95,15 @@ groupProportion <- function(data, x = NULL, y, group = NULL, panel = NULL, colla
     dt <- data.table::as.data.table(t(1)) # Without any grouping, proportion should always be 1
   } else {
 
+    # Aggregate to get counts of value per group
     dt <- data.table::as.data.table(aggregate(as.formula(aggStr), data, length))
     strataCols <- c(group, panel)
     
     # If there are no strata vars, then we don't need the by term
     if (is.null(strataCols)) {
-      dt[, sum := sum(get(y))][, prop := get(y)/sum]
+      dt[, sum := sum(get(y))][, proportion := get(y)/sum]
     } else {
-      dt[, sum := sum(get(y)), by=strataCols][, prop := get(y)/sum]
+      dt[, sum := sum(get(y)), by=strataCols][, proportion := get(y)/sum]
     }
     
     # Remove unnecessary columns
@@ -120,10 +121,6 @@ groupProportion <- function(data, x = NULL, y, group = NULL, panel = NULL, colla
   }
   
   return(dt)
-}
-
-proportion <- function(x) {
-  sum(x)/length(x)
 }
 
 

--- a/R/group.R
+++ b/R/group.R
@@ -92,21 +92,23 @@ groupProportion <- function(data, x = NULL, y, group = NULL, panel = NULL, colla
   aggStr <- getAggStr(y, c(x, group, panel))
   
   if (aggStr == y) {
-    # dt <- data.table::as.data.table(t(length(data[[y]])))
-    dt <- data.table::as.data.table(t(1)) #### Without grouping proportion should always be 1
+    dt <- data.table::as.data.table(t(1)) # Without any grouping, proportion should always be 1
   } else {
-    dt <- data.table::as.data.table(aggregate(as.formula(aggStr), .pd, length))
-    # dtb <- data.table::as.data.table(aggregate(as.formula(aggStr), .pd, length))
-    neededCols <- c(group, panel)
-    # dtc <- dtb[, sum := sum(dummy), by=neededCols][, prop := dummy/sum]
-    dt[, sum := sum(get(y)), by=neededCols][, prop := get(y)/sum]
+
+    dt <- data.table::as.data.table(aggregate(as.formula(aggStr), data, length))
+    strataCols <- c(group, panel)
+    
+    # If there are no strata vars, then we don't need the by term
+    if (is.null(strataCols)) {
+      dt[, sum := sum(get(y))][, prop := get(y)/sum]
+    } else {
+      dt[, sum := sum(get(y)), by=strataCols][, prop := get(y)/sum]
+    }
     
     # Remove unnecessary columns
     dt[, sum := NULL]
     dt[, (y) := NULL]
     
-    # myy <- c(y)
-    # dtb <- dta[, sum := ..myy]
   }
   
   data.table::setnames(dt, c(x, group, panel, 'proportion'))

--- a/tests/testthat/test-bar.R
+++ b/tests/testthat/test-bar.R
@@ -12,6 +12,16 @@ test_that("bar.dt() returns an appropriately sized data.table", {
   expect_equal(nrow(dt),16)
   expect_equal(names(dt),c('panel', 'label', 'value'))
   expect_equal(all(grepl('.||.', dt$panel, fixed=T)), TRUE)
+  
+  dt <- bar.dt(df, map, value='proportion')
+  expect_is(dt, 'data.table')
+  expect_is(dt, 'barplot')
+  expect_is(dt$label, 'list')
+  expect_is(dt$value, 'list')
+  expect_equal(nrow(dt),16)
+  expect_equal(names(dt),c('panel', 'label', 'value'))
+  expect_equal(all(grepl('.||.', dt$panel, fixed=T)), TRUE)
+  expect_equal(all(lapply(dt$value, sum) == 1), TRUE)
 
   map <- data.frame('id' = c('group', 'x', 'panel'), 'plotRef' = c('overlayVariable', 'xAxisVariable', 'facetVariable1'), 'dataType' = c('STRING', 'STRING', 'STRING'), stringsAsFactors=FALSE)
   df <- as.data.frame(data.binned)
@@ -23,6 +33,15 @@ test_that("bar.dt() returns an appropriately sized data.table", {
   expect_is(dt$value, 'list')
   expect_equal(nrow(dt),16)
   expect_equal(names(dt),c('group', 'panel', 'label', 'value'))
+  
+  dt <- bar.dt(df, map, value='proportion')
+  expect_is(dt, 'data.table')
+  expect_is(dt, 'barplot')
+  expect_is(dt$label, 'list')
+  expect_is(dt$value, 'list')
+  expect_equal(nrow(dt),16)
+  expect_equal(names(dt),c('group', 'panel', 'label', 'value'))
+  expect_equal(all(lapply(dt$value, sum) == 1), TRUE)
 
   map <- data.frame('id' = c('group', 'x'), 'plotRef' = c('overlayVariable', 'xAxisVariable'), 'dataType' = c('STRING', 'STRING'), stringsAsFactors=FALSE)
 
@@ -30,10 +49,21 @@ test_that("bar.dt() returns an appropriately sized data.table", {
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),4)
   expect_equal(names(dt),c('group', 'label', 'value'))
+  
+  dt <- bar.dt(df, map, value='proportion')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),4)
+  expect_equal(names(dt),c('group', 'label', 'value'))
+  expect_equal(all(lapply(dt$value, sum) == 1), TRUE)
 
   map <- data.frame('id' = c('x'), 'plotRef' = c('xAxisVariable'), 'dataType' = c('STRING'), stringsAsFactors=FALSE)
 
   dt <- bar.dt(df, map, value='count')
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),1)
+  expect_equal(names(dt),c('label', 'value'))
+  
+  dt <- bar.dt(df, map, value='proportion')
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),1)
   expect_equal(names(dt),c('label', 'value'))

--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -118,3 +118,18 @@ test_that("groupDensity() returns consistent results", {
   dt <- groupDensity(data.xy, 'y', 'group', 'panel')
   expect_equal_to_reference(dt,"density.group.panel.rds")
 })
+
+test_that("groupProportion() returns values that sum to 1", {
+  df <- data.frame("labels"=c("a","a","b","b","c"), "counts"=c(1,1, 1, 1, 1), "group"=c("g1","g2","g1","g2","g1"))
+  dt <- groupProportion(df, x="labels", y="counts")
+  expect_equal(sum(dt$proportion[[1]]), 1)
+  dt <- groupProportion(df, x="labels", y="counts", group="group")
+  expect_equal(all(lapply(dt$proportion, sum) == 1), TRUE)
+})
+
+test_that("groupProportion() maps to groupSize() correctly", {
+  df <- data.frame("labels"=c("a","a","b","b","a"), "counts"=c(1,1, 1, 1, 1))
+  dt_size <- groupSize(df, x="labels", y="counts")
+  dt_prop <- groupProportion(df, x="labels", y="counts")
+  expect_equal(dt_size$size[[1]]/sum(dt_size$size[[1]]), dt_prop$proportion[[1]])
+})


### PR DESCRIPTION
# Feature: Bar returns proportion

In response to issue #28, this PR adds an additional option to the bar plot. Specifically, the `value` argument for `bar.dt` and `bar` now accepts one of `c('count', 'identity', 'proportion')`. 

The majority of the heavy lifting is done by the new function `groupProportion` which follows the same structure as `groupSize` but returns proportions per group instead of counts.

Added new tests in `test-bar.R` and `test-group.R`. 