### PR TITLE
Feature/27/prepare scatter for gradient colorscale

### DIFF
--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -128,10 +128,11 @@ validateScatterPD <- function(.scatter) {
 #' 'smoothedMeanY' and 'smoothedMeanSE' specify the x, y and 
 #' standard error respectively of the smoothed conditional mean 
 #' for the group. Columns 'densityX' and 'densityY' contain the 
-#' calculated kernel density estimates.
+#' calculated kernel density estimates. Column 'seriesGradientColorscale'
+#' contains values to be used with a gradient colorscale when plotting.
 #' @param data data.frame to make plot-ready data for
 #' @param map data.frame with at least two columns (id, plotRef) indicating a variable sourceId and its position in the plot. Recognized plotRef values are 'xAxisVariable', 'yAxisVariable', 'overlayVariable', 'facetVariable1' and 'facetVariable2'
-#' @param value character indicating whether to calculate 'smoothedMean', 'bestFitLineWithRaw' or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw data with smoothed mean
+#' @param value character indicating whether to calculate 'smoothedMean', 'bestFitLineWithRaw' or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw data with smoothed mean. Note only 'raw' is compatible with a continuous overlay variable.
 #' @return data.table plot-ready data
 #' @export
 scattergl.dt <- function(data, 
@@ -208,10 +209,11 @@ scattergl.dt <- function(data,
 #' 'smoothedMeanY' and 'smoothedMeanSE' specify the x, y and 
 #' standard error respectively of the smoothed conditional mean 
 #' for the group. Columns 'densityX' and 'densityY' contain the 
-#' calculated kernel density estimates.
+#' calculated kernel density estimates. Column 'seriesGradientColorscale'
+#' contains values to be used with a gradient colorscale when plotting.
 #' @param data data.frame to make plot-ready data for
 #' @param map data.frame with at least two columns (id, plotRef) indicating a variable sourceId and its position in the plot. Recognized plotRef values are 'xAxisVariable', 'yAxisVariable', 'overlayVariable', 'facetVariable1' and 'facetVariable2'
-#' @param value character indicating whether to calculate 'smoothedMean', 'bestFitLineWithRaw' or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw data with smoothed mean
+#' @param value character indicating whether to calculate 'smoothedMean', 'bestFitLineWithRaw' or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw data with smoothed mean. Note only 'raw' is compatible with a continuous overlay variable.
 #' @return character name of json file containing plot-ready data
 #' @export
 scattergl <- function(data, map, value = c('smoothedMean', 'smoothedMeanWithRaw', 'bestFitLineWithRaw', 'density', 'raw')) {

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -38,8 +38,14 @@ newScatterPD <- function(.dt = data.table::data.table(),
   group <- attr$overlayVariable$variableId
   panel <- findPanelColName(attr$facetVariable1$variableId, attr$facetVariable2$variableId)
 
-  series <- collapseByGroup(.pd, group, panel)
-  data.table::setnames(series, c(group, panel, 'seriesX', 'seriesY'))
+  if (attr$overlayVariable$dataShape == 'CONTINUOUS') {
+    series <- collapseByGroup(.pd, group = NULL, panel)
+    data.table::setnames(series, c(panel, 'seriesX', 'seriesY', group))
+  } else {
+    series <- collapseByGroup(.pd, group, panel)
+    data.table::setnames(series, c(group, panel, 'seriesX', 'seriesY'))
+  }
+  
   series$seriesX <- lapply(series$seriesX, as.character)
   series$seriesY <- lapply(series$seriesY, as.character)
 

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -96,12 +96,12 @@ validateScatterPD <- function(.scatter) {
   if (!yAxisVariable$dataShape %in% c('CONTINUOUS')) {
     stop('The dependent axis must be continuous for scatterplot.')
   }
-  # overlayVariable <- attr(.scatter, 'overlayVariable')
-  # if (!is.null(overlayVariable)) {
-  #   if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #     stop('The overlay variable must be binary, ordinal or categorical.')
-  #   }
-  # }
+  overlayVariable <- attr(.scatter, 'overlayVariable')
+  if (!is.null(overlayVariable)) {
+    if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL', 'CONTINUOUS')) {
+      stop('The overlay variable must be binary, ordinal, categorical, or continuous.')
+    }
+  }
   facetVariable1 <- attr(.scatter, 'facetVariable1')
   if (!is.null(facetVariable1)) {
     if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -38,7 +38,7 @@ newScatterPD <- function(.dt = data.table::data.table(),
   group <- attr$overlayVariable$variableId
   panel <- findPanelColName(attr$facetVariable1$variableId, attr$facetVariable2$variableId)
 
-  if (attr$overlayVariable$dataShape == 'CONTINUOUS') {
+  if (identical(attr$overlayVariable$dataShape,'CONTINUOUS')) {
     series <- collapseByGroup(.pd, group = NULL, panel)
     data.table::setnames(series, c(panel, 'seriesX', 'seriesY', group))
   } else {

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -40,7 +40,7 @@ newScatterPD <- function(.dt = data.table::data.table(),
 
   if (identical(attr$overlayVariable$dataShape,'CONTINUOUS')) {
     series <- collapseByGroup(.pd, group = NULL, panel)
-    data.table::setnames(series, c(panel, 'seriesX', 'seriesY', group))
+    data.table::setnames(series, c(panel, 'seriesX', 'seriesY', 'seriesGradientColorscale'))
   } else {
     series <- collapseByGroup(.pd, group, panel)
     data.table::setnames(series, c(group, panel, 'seriesX', 'seriesY'))

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -90,12 +90,12 @@ validateScatterPD <- function(.scatter) {
   if (!yAxisVariable$dataShape %in% c('CONTINUOUS')) {
     stop('The dependent axis must be continuous for scatterplot.')
   }
-  overlayVariable <- attr(.scatter, 'overlayVariable')
-  if (!is.null(overlayVariable)) {
-    if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-      stop('The overlay variable must be binary, ordinal or categorical.')
-    }
-  }
+  # overlayVariable <- attr(.scatter, 'overlayVariable')
+  # if (!is.null(overlayVariable)) {
+  #   if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
+  #     stop('The overlay variable must be binary, ordinal or categorical.')
+  #   }
+  # }
   facetVariable1 <- attr(.scatter, 'facetVariable1')
   if (!is.null(facetVariable1)) {
     if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
@@ -168,6 +168,9 @@ scattergl.dt <- function(data,
   }
   if ('overlayVariable' %in% map$plotRef) {
     overlayVariable <- plotRefMapToList(map, 'overlayVariable')
+    if (overlayVariable$dataShape == 'CONTINUOUS' & value != 'raw') {
+      stop('Continuous overlay variables cannot be used with trend lines.')
+    }
   }
   if ('facetVariable1' %in% map$plotRef) {
     facetVariable1 <- plotRefMapToList(map, 'facetVariable1')

--- a/R/class-plotdata.R
+++ b/R/class-plotdata.R
@@ -60,13 +60,16 @@ newPlotdata <- function(.dt = data.table(),
   incompleteCases <- jsonlite::unbox(nrow(.dt[!complete.cases(.dt),]))
   
   .dt <- .dt[complete.cases(.dt),]
+  
+  # If overlay is continuous, it does not contribute to final groups
+  overlayGroup <- if (identical(overlayVariable$dataShape,'CONTINUOUS')) NULL else group
 
   if (xType == 'STRING') {
     .dt$dummy <- 1
-    sampleSizeTable <- groupSize(.dt, x=x, y="dummy", group, panel, collapse=F)
+    sampleSizeTable <- groupSize(.dt, x=x, y="dummy", overlayGroup, panel, collapse=F)
     .dt$dummy <- NULL
   } else {
-    sampleSizeTable <- groupSize(.dt, x=NULL, y=x, group, panel, collapse=F)
+    sampleSizeTable <- groupSize(.dt, x=NULL, y=x, overlayGroup, panel, collapse=F)
   }
   sampleSizeTable$size <- lapply(sampleSizeTable$size, jsonlite::unbox)
 
@@ -85,7 +88,7 @@ newPlotdata <- function(.dt = data.table(),
   if (!is.null(z)) { attr$yAxisVariable <- zAxisVariable }
   attr$incompleteCases <- incompleteCases
   attr$completeCasesTable <- completeCasesTable
-  attr$sampleSizeTable <- collapseByGroup(sampleSizeTable, group, panel)
+  attr$sampleSizeTable <- collapseByGroup(sampleSizeTable, overlayGroup, panel)
   attr$class = c(class, 'plot.data', attr$class)
   if (!is.null(group)) { attr$overlayVariable <- overlayVariable }
   if (!is.null(facet1)) { attr$facetVariable1 <- facetVariable1 }

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -39,8 +39,10 @@ addStrataVariableDetails <- function(.pd) {
   # !!!!! work off a copy while writing json
   # since we have two exported fxns, dont want calling one changing the result of the other
   if (!is.null(group)) {
-    names(.pd)[names(.pd) == group] <- 'overlayVariableDetails'
-    .pd$overlayVariableDetails <- lapply(.pd$overlayVariableDetails, makeVariableDetails, group, namedAttrList$overlayVariable$entityId)
+    if (!identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS')) {
+      names(.pd)[names(.pd) == group] <- 'overlayVariableDetails'
+      .pd$overlayVariableDetails <- lapply(.pd$overlayVariableDetails, makeVariableDetails, group, namedAttrList$overlayVariable$entityId)
+    }
   }
 
   if (!is.null(facet1) & !is.null(facet2)) {
@@ -102,6 +104,12 @@ getJSON <- function(.pd) {
   }
 
   .pd <- addStrataVariableDetails(.pd)
+  
+  # If overlay is continuous, handle similarly to x, y, z vars.
+  if ('overlayVariable' %in% names(namedAttrList) & identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS')) {
+    namedAttrList$overlayVariableDetails <- makeVariableDetails(NULL, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId)
+  }
+  
   namedAttrList$overlayVariable <- NULL
   namedAttrList$facetVariable1 <- NULL
   namedAttrList$facetVariable2 <- NULL

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -103,17 +103,6 @@ getJSON <- function(.pd) {
     completeCasesTable <- setAttrFromList(completeCasesTable, attr)
   }
 
-  .pd <- addStrataVariableDetails(.pd)
-  
-  # If overlay is continuous, handle similarly to x, y, z vars.
-  if ('overlayVariable' %in% names(namedAttrList) & identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS')) {
-    namedAttrList$overlayVariableDetails <- makeVariableDetails(NULL, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId)
-  }
-  
-  namedAttrList$overlayVariable <- NULL
-  namedAttrList$facetVariable1 <- NULL
-  namedAttrList$facetVariable2 <- NULL
-
   if ('xAxisVariable' %in% names(namedAttrList)) {
     namedAttrList$xVariableDetails <- makeVariableDetails(NULL, namedAttrList$xAxisVariable$variableId, namedAttrList$xAxisVariable$entityId)
     namedAttrList$xAxisVariable <- NULL
@@ -126,6 +115,18 @@ getJSON <- function(.pd) {
     namedAttrList$zVariableDetails <- makeVariableDetails(NULL, namedAttrList$zAxisVariable$variableId, namedAttrList$zAxisVariable$entityId)
     namedAttrList$zAxisVariable <- NULL
   }
+  
+  .pd <- addStrataVariableDetails(.pd)
+  # If overlay is continuous, handle similarly to x, y, z vars.
+  if ('overlayVariable' %in% names(namedAttrList) & identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS')) {
+    namedAttrList$overlayVariableDetails <- makeVariableDetails(NULL, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId)
+  }
+  
+  namedAttrList$facetVariable1 <- NULL
+  namedAttrList$facetVariable2 <- NULL
+  namedAttrList$overlayVariable <- NULL
+
+  
 
   
   outList <- list(class = list('data'=.pd, 'config'=namedAttrList))

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -148,6 +148,14 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   df[, z := runif(500)]
   
   dt <- scattergl.dt(df, map, 'raw')
+  expect_equal(nrow(dt), 1)
+  expect_equal(names(dt), c('seriesX', 'seriesY', 'z'))
+  expect_true(identical(dt$z[[1]], df$z))
+  
+  
+  
+  
+  
 })
 
 test_that("scattergl() returns appropriately formatted json", {

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -150,20 +150,20 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   
   dt <- scattergl.dt(df, map, 'raw')
   expect_equal(nrow(dt), 1)
-  expect_equal(names(dt), c('seriesX', 'seriesY', 'z'))
-  expect_true(identical(dt$z[[1]], df$z))
+  expect_equal(names(dt), c('seriesX', 'seriesY', 'seriesGradientColorscale'))
+  expect_true(identical(dt$seriesGradientColorscale[[1]], df$z))
   
   map <- data.frame('id' = c('group', 'y', 'x', 'panel', 'z'), 'plotRef' = c('facetVariable2', 'yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'), 'dataType' = c('STRING', 'NUMBER', 'NUMBER', 'STRING', 'NUMBER'), 'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
   dt <- scattergl.dt(df, map, 'raw')
   expect_equal(nrow(dt), 16)
-  expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'z'))
-  expect_equal(length(dt$z[[1]]), length(dt$seriesX[[1]]))
+  expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'seriesGradientColorscale'))
+  expect_equal(length(dt$seriesGradientColorscale[[1]]), length(dt$seriesX[[1]]))
   
   map <- data.frame('id' = c('y', 'x', 'panel', 'z'), 'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'), 'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'), 'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
   dt <- scattergl.dt(df, map, 'raw')
   expect_equal(nrow(dt), 4)
-  expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'z'))
-  expect_equal(length(dt$z[[1]]), length(dt$seriesX[[1]]))
+  expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'seriesGradientColorscale'))
+  expect_equal(length(dt$seriesGradientColorscale[[1]]), length(dt$seriesX[[1]]))
   
   
 })

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -143,6 +143,7 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(nrow(dt),1)
   expect_equal(names(dt),c('densityX', 'densityY'))
   
+  # Continuous overlay
   map <- data.frame('id' = c('z', 'y', 'x'), 'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'), 'dataType' = c('NUMBER', 'NUMBER', 'NUMBER'), 'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CONTINUOUS'), stringsAsFactors=FALSE)
   df <- data.xy
   df[, z := runif(500)]
@@ -152,8 +153,17 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(names(dt), c('seriesX', 'seriesY', 'z'))
   expect_true(identical(dt$z[[1]], df$z))
   
+  map <- data.frame('id' = c('group', 'y', 'x', 'panel', 'z'), 'plotRef' = c('facetVariable2', 'yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'), 'dataType' = c('STRING', 'NUMBER', 'NUMBER', 'STRING', 'NUMBER'), 'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
+  dt <- scattergl.dt(df, map, 'raw')
+  expect_equal(nrow(dt), 16)
+  expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'z'))
+  expect_equal(length(dt$z[[1]]), length(dt$serisX[[1]]))
   
-  
+  map <- data.frame('id' = c('y', 'x', 'panel', 'z'), 'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'), 'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'), 'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
+  dt <- scattergl.dt(df, map, 'raw')
+  expect_equal(nrow(dt), 4)
+  expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'z'))
+  expect_equal(length(dt$z[[1]]), length(dt$serisX[[1]]))
   
   
 })

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -184,6 +184,29 @@ test_that("scattergl() returns appropriately formatted json", {
   expect_equal(names(jsonList$scatterplot$config$xVariableDetails),c('variableId','entityId'))
   expect_equal(names(jsonList$sampleSizeTable),c('overlayVariableDetails','facetVariableDetails','size'))
   expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
+  
+  
+  dt <- scattergl.dt(df, map, 'raw')
+  outJson <- getJSON(dt)
+  jsonList <- jsonlite::fromJSON(outJson)
+  
+  
+  map <- data.frame('id' = c('y', 'x', 'panel', 'z'), 'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'), 'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'), 'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
+  df[, z := runif(500)]
+  dt <- scattergl.dt(df, map, 'raw')
+  outJson <- getJSON(dt)
+  jsonList <- jsonlite::fromJSON(outJson)
+  
+  expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
+  expect_equal(names(jsonList$scatterplot),c('data','config'))
+  expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','seriesX','seriesY','seriesGradientColorscale'))
+  expect_equal(names(jsonList$scatterplot$data$facetVariableDetails),c('variableId','entityId','value'))
+  expect_equal(nrow(jsonList$scatterplot$data$facetVariableDetails), 4)
+  expect_equal(names(jsonList$scatterplot$config),c('incompleteCases','xVariableDetails','yVariableDetails','overlayVariableDetails'))
+  expect_equal(names(jsonList$scatterplot$config$overlayVariableDetails),c('variableId','entityId'))
+  expect_equal(names(jsonList$sampleSizeTable),c('facetVariableDetails','size'))
+  expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
+
 })
 
 

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -142,6 +142,12 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),1)
   expect_equal(names(dt),c('densityX', 'densityY'))
+  
+  map <- data.frame('id' = c('z', 'y', 'x'), 'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'), 'dataType' = c('NUMBER', 'NUMBER', 'NUMBER'), 'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CONTINUOUS'), stringsAsFactors=FALSE)
+  df <- data.xy
+  df[, z := runif(500)]
+  
+  dt <- scattergl.dt(df, map, 'raw')
 })
 
 test_that("scattergl() returns appropriately formatted json", {

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -157,13 +157,13 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   dt <- scattergl.dt(df, map, 'raw')
   expect_equal(nrow(dt), 16)
   expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'z'))
-  expect_equal(length(dt$z[[1]]), length(dt$serisX[[1]]))
+  expect_equal(length(dt$z[[1]]), length(dt$seriesX[[1]]))
   
   map <- data.frame('id' = c('y', 'x', 'panel', 'z'), 'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'), 'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'), 'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
   dt <- scattergl.dt(df, map, 'raw')
   expect_equal(nrow(dt), 4)
   expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'z'))
-  expect_equal(length(dt$z[[1]]), length(dt$serisX[[1]]))
+  expect_equal(length(dt$z[[1]]), length(dt$seriesX[[1]]))
   
   
 })


### PR DESCRIPTION
Addresses issue #27 

This PR allows the overlay variable passed to `scattergl.dt` to be continuous. 

## Rules for continuous overlay variables:
- No trend lines. `scattergl.dt` will err if passed a continuous overlay var and `value != 'raw`. 
- Continuous overlay vars operate as one group. In other words, there is one row in the resulting data.table per panel, not per overlay var and panel (as is the case otherwise).The overlay var is returned as a list that should have the same length as `'seriesX'` and `'seriesY'`.

## Testing
New tests added to the scattergl context. All relevant tests pass.

## Notes
- Instead of being ordered, `c(group, panel, 'seriesX', 'seriesY') `, the returned pd data.table will have columns `c(panel, 'seriesX', 'seriesY', group)`. I do not expect this to be a problem but can reorder if that is not the case!
- Decided to keep the overlay var validation step in validateScatterPD in case we for some reason are send an overlay var with `dataShape=zebra`, etc.

