### PR TITLE
Fix/55/integer bin widths

### DIFF
--- a/R/utils-bin.R
+++ b/R/utils-bin.R
@@ -90,15 +90,14 @@ findBinWidth <- function(x) UseMethod("findBinWidth")
 findBinWidth.numeric <- function(x) {
   numBins <- findNumBins(x)
   binWidth <- numBinsToBinWidth(x, numBins)
-  avgDigits <- floor(mean(stringr::str_count(as.character(x), "[[:digit:]]")))
-
   if (all(x %% 1 == 0)) {
     # Then x only contains integers, so the binWidth should also be an integer
-    binWidth <- ceiling(binWidth)
+    avgDigits <- 0
   } else {
     # Then x contains data with non-zero decimals, so the binWidth can be any float
-    binWidth <- round(binWidth, avgDigits)
+    avgDigits <- floor(mean(stringr::str_count(as.character(x), "[[:digit:]]")))
   }
+  binWidth <- round(binWidth, avgDigits)
 
   return(binWidth)
 }

--- a/R/utils-bin.R
+++ b/R/utils-bin.R
@@ -91,7 +91,14 @@ findBinWidth.numeric <- function(x) {
   numBins <- findNumBins(x)
   binWidth <- numBinsToBinWidth(x, numBins)
   avgDigits <- floor(mean(stringr::str_count(as.character(x), "[[:digit:]]")))
-  binWidth <- round(binWidth, avgDigits)
+
+  if (all(x %% 1 == 0)) {
+    # Then x only contains integers, so the binWidth should also be an integer
+    binWidth <- ceiling(binWidth)
+  } else {
+    # Then x contains data with non-zero decimals, so the binWidth can be any float
+    binWidth <- round(binWidth, avgDigits)
+  }
 
   return(binWidth)
 }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -224,3 +224,27 @@ test_that("nonparametricTest() types do not change on error", {
   expect_equal(lapply(result_correct[[1]], typeof), lapply(result_err[[1]], typeof))
 })
 
+test_that("findBinWidth returns appropriate bin types for numeric inputs", {
+  # Integers should return integer bin width
+  x <- c(1.0, 4.0, 2.0, 9.0, 4.0, 1.0, 8.0, 11.0, 34.0, 23.0, 19.0)
+  binWidth <- findBinWidth(x)
+  expect_true(is.numeric(binWidth))
+  expect_equal(binWidth%%1, 0)
+  
+  x <- c(1.0, -4.0, 2.0, 9.0, 4.0, -1.0, 8.0, -11.0, 34.0, 23.0, -19.0)
+  binWidth <- findBinWidth(x)
+  expect_true(is.numeric(binWidth))
+  expect_equal(binWidth%%1, 0)
+  
+  x <- sample(-100:100, 100, replace=T)
+  binWidth <- findBinWidth(x)
+  expect_true(is.numeric(binWidth))
+  expect_equal(binWidth%%1, 0)
+  
+  # Values with non-zero decimals should return numeric
+  x <- runif(100, min=-1, max=1)
+  binWidth <- findBinWidth(x)
+  expect_true(is.numeric(binWidth))
+  
+})
+


### PR DESCRIPTION
_Fix for issue #55_

Goal: If `binWidth` is not supplied, `findBinWidth1 should return an integer if its input data are all integers.

The proposed fix requires two parts:
1. Determine if the input vector are all integers
2. If 1 is true, round the bin width appropriately.

For 1. , if `x` is an integer, then `x %%1  = 0`. This works for numbers passed with or without decimals (`6 %% 1 = 0` and `6.0 %% 1 = 0`).

For 2., round to nearest integer (alternatives: floor, ceiling).

## Testing
Added tests for `findBinWidth` to `test-utils.R`