### PR TITLE
Bug/73/box statsTable structure

### DIFF
--- a/R/utils-stats.R
+++ b/R/utils-stats.R
@@ -330,11 +330,10 @@ nonparametricTest <- function(values, groups) {
       "parameter" = numeric(),
       "method" = character(),
       "statsError" = jsonlite::unbox(as.character(testResult[1])))
-    testResult <- list(testResult)
   } else {
     testResult$parameter <- as.numeric(testResult$parameter)
     names(testResult)[names(testResult) == 'p.value'] <- 'pvalue'
-    testResult <- list(c(testResult[c('statistic', 'pvalue', 'parameter', 'method')], "statsError" = jsonlite::unbox("")))
+    testResult <- c(testResult[c('statistic', 'pvalue', 'parameter', 'method')], "statsError" = jsonlite::unbox(""))
   }
   
   return(testResult)
@@ -346,14 +345,17 @@ nonparametricByGroup <- function(data, numericCol, levelsCol, byCols = NULL) {
   setDT(data)
   
   if (is.null(byCols)) {
-    statsResults <- data.table::as.data.table(t(nonparametricTest(data[[numericCol]], data[[levelsCol]])))
+    dt <- data.table::as.data.table(t(nonparametricTest(data[[numericCol]], data[[levelsCol]])))
   } else {
-    statsResults <- data[, .(nonparametricTest(get(..numericCol), get(..levelsCol))) , by=eval(colnames(data)[colnames(data) %in% byCols])]
+    dt <- data[, {testResult <- nonparametricTest(get(..numericCol), get(..levelsCol));
+                    list(statistic=testResult$statistic,
+                          pvalue=testResult$pvalue,
+                          parameter=testResult$parameter,
+                          method=testResult$method,
+                          statsError=testResult$statsError)} , by=eval(colnames(data)[colnames(data) %in% byCols])]
   }
-  
-  data.table::setnames(statsResults, 'V1', 'statistics')
 
-  return (statsResults)
+  return (dt)
   
 }
 

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -15,7 +15,7 @@ test_that("box.dt() returns a valid plot.data box object", {
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(names(sampleSizes), c('entity.group','entity.panel','size'))
   expect_equal(nrow(sampleSizes), 4)
-  expect_equal(names(namedAttrList$statsTable), c('entity.panel','statistics'))
+  expect_equal(names(namedAttrList$statsTable), c('entity.panel','statistic','pvalue','parameter','method','statsError'))
   
   dt <- box.dt(df, map, 'all', FALSE)
   expect_is(dt, 'plot.data')
@@ -27,7 +27,7 @@ test_that("box.dt() returns a valid plot.data box object", {
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(names(sampleSizes), c('entity.group','entity.panel','size'))
   expect_equal(nrow(sampleSizes), 4)
-  expect_equal(names(namedAttrList$statsTable), c('entity.panel','statistics'))
+  expect_equal(names(namedAttrList$statsTable), c('entity.panel','statistic','pvalue','parameter','method','statsError'))
   expect_equal(dt$entity.group[[1]], 'group1')
   expect_equal(dt$label[[1]], c('panel1','panel2','panel3','panel4'))
   expect_equal(unlist(lapply(dt$rawData[[1]], length)), c(25,50,25,25))
@@ -200,7 +200,7 @@ test_that("box() returns appropriately formatted json", {
   expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
   expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
-  expect_equal(names(jsonList$statsTable), c('entity.panel','statistics','overlayVariableDetails'))
+  expect_equal(names(jsonList$statsTable), c('entity.panel','statistic','pvalue','parameter','method','statsError','overlayVariableDetails'))
 
   map <- data.frame('id' = c('entity.group', 'entity.y', 'entity.panel'), 'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'), 'dataType' = c('STRING', 'NUMBER', 'STRING'), 'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CATEGORICAL'), 'displayLabel' = c('groupLabel','yLabel','panelLabel'), stringsAsFactors=FALSE)
 
@@ -217,7 +217,7 @@ test_that("box() returns appropriately formatted json", {
   expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
   expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId','displayLabel'))
-  expect_equal(names(jsonList$statsTable), c('entity.panel','statistics','overlayVariableDetails'))
+  expect_equal(names(jsonList$statsTable), c('entity.panel','statistic','pvalue','parameter','method','statsError','overlayVariableDetails'))
 
   map <- data.frame('id' = c('entity.group', 'entity.y', 'entity.panel'), 'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'), 'dataType' = c('STRING', 'NUMBER', 'STRING'), 'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CATEGORICAL'), 'displayLabel' = c('','','panelLabel'), stringsAsFactors=FALSE)
 
@@ -247,7 +247,7 @@ test_that("box() returns appropriately formatted json", {
   expect_equal(names(jsonList$sampleSizeTable), c('overlayVariableDetails','xVariableDetails','size'))
   expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
-  expect_equal(names(jsonList$statsTable), c('entity.numcat1','statistics','overlayVariableDetails'))
+  expect_equal(names(jsonList$statsTable), c('entity.numcat1','statistic','pvalue','parameter','method','statsError','overlayVariableDetails'))
   expect_equal(class(jsonList$boxplot$data$label[[1]]), 'character')
 })
 
@@ -309,28 +309,28 @@ test_that("box.dt() returns an appropriately sized statistics table", {
   dt <- box.dt(df, map, 'none', FALSE, TRUE)
   statsTable <- attr(dt, 'statsTable')
   expect_equal(nrow(statsTable), 1)
-  expect_equal(ncol(statsTable), 1)
+  expect_equal(ncol(statsTable), 5)
   
   # No overlay, one facet
   map <- data.frame('id' = c('entity.xcat', 'entity.y', 'entity.panel'), 'plotRef' = c('xAxisVariable', 'yAxisVariable', 'facetVariable1'), 'dataType' = c('STRING', 'NUMBER', 'STRING'), 'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CATEGORICAL'), stringsAsFactors=FALSE)
   dt <- box.dt(df, map, 'none', FALSE, TRUE)
   statsTable <- attr(dt, 'statsTable')
   expect_equal(nrow(statsTable), uniqueN(df$entity.panel))
-  expect_equal(ncol(statsTable), 2)
+  expect_equal(ncol(statsTable), 6)
   
   # With overlay, no facets
   map <- data.frame('id' = c('entity.xcat', 'entity.y', 'entity.group'), 'plotRef' = c('xAxisVariable', 'yAxisVariable', 'overlayVariable'), 'dataType' = c('STRING', 'NUMBER', 'STRING'), 'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CATEGORICAL'), stringsAsFactors=FALSE)
   dt <- box.dt(df, map, 'none', FALSE, TRUE)
   statsTable <- attr(dt, 'statsTable')
   expect_equal(nrow(statsTable), uniqueN(df$entity.xcat))
-  expect_equal(ncol(statsTable), 2)
+  expect_equal(ncol(statsTable), 6)
   
   # With overlay and facet
   map <- data.frame('id' = c('entity.xcat', 'entity.y', 'entity.group', 'entity.panel'), 'plotRef' = c('xAxisVariable', 'yAxisVariable', 'overlayVariable', 'facetVariable1'), 'dataType' = c('STRING', 'NUMBER', 'STRING', 'STRING'), 'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CATEGORICAL', 'CATEGORICAL'), stringsAsFactors=FALSE)
   dt <- box.dt(df, map, 'none', FALSE, TRUE)
   statsTable <- attr(dt, 'statsTable')
   expect_equal(nrow(statsTable), uniqueN(df$entity.xcat)*uniqueN(df$entity.panel))
-  expect_equal(ncol(statsTable), 3)
+  expect_equal(ncol(statsTable), 7)
   
   
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -241,7 +241,7 @@ test_that("remapListVar appropriately updates map", {
 test_that("nonparametricTest() errs gracefully", {
   df <- as.data.frame(data.xy)
   result <- nonparametricTest(df$entity.x[df$entity.group == 'group1'], df$entity.group[df$entity.group == 'group1'])
-  expect_true(grepl( 'Error', result[[1]]$statsError, fixed = TRUE))
+  expect_true(grepl( 'Error', result$statsError, fixed = TRUE))
   
 })
 
@@ -258,15 +258,15 @@ test_that("nonparametricTest() types do not change on error", {
   df <- as.data.frame(data.xy)
   result_correct <- nonparametricTest(df$entity.x, df$entity.group)    # kruskal.test
   result_err <- nonparametricTest(df$entity.x[df$entity.group == 'group1'], df$entity.group[df$entity.group == 'group1'])
-  expect_true(grepl( 'Error', result_err[[1]]$statsError, fixed = TRUE))
-  expect_equal(result_correct[[1]]$statsError, '')
-  expect_equal(lapply(result_correct[[1]], typeof), lapply(result_err[[1]], typeof))
+  expect_true(grepl( 'Error', result_err$statsError, fixed = TRUE))
+  expect_equal(result_correct$statsError, '')
+  expect_equal(lapply(result_correct, typeof), lapply(result_err, typeof))
   
   df$entity.group[df$entity.group =='group3'] <- 'group1'
   df$entity.group[df$entity.group == 'group4'] <- 'group2'
   result_correct <- nonparametricTest(df$entity.x, df$entity.group)    # wilcox.test
-  expect_equal(result_correct[[1]]$statsError, '')
-  expect_equal(lapply(result_correct[[1]], typeof), lapply(result_err[[1]], typeof))
+  expect_equal(result_correct$statsError, '')
+  expect_equal(lapply(result_correct, typeof), lapply(result_err, typeof))
 })
 
 test_that("findBinWidth returns appropriate bin types for numeric inputs", {


### PR DESCRIPTION
_Addresses issue #73_

The box's `statsTable` originally had all the statistics wrapped into a list. Mosaic's `statsTable` instead has one column per stat (see `TwoByTwoStatsTable` in the DS). 

This PR updated `nonParametericTest` and `nonParametricTestByGroup` so that their output was one data table with statistics as columns.

## To Dos
- [ ] Add more tests