### PR TITLE
Fix/87/mosaic-stats

### DIFF
--- a/R/class-plotdata-mosaic.R
+++ b/R/class-plotdata-mosaic.R
@@ -132,11 +132,12 @@ mosaic.dt <- function(data, map,
     if (!statistic %in% c('chiSq','bothRatios')) {
       stop('`statistic` argument must be one of either \'chiSq\' or \'bothRatios\', the second of which returns both odds ratios and relative risk.')
     }
-    if ((data.table::uniqueN(data[[x]]) > 2 || data.table::uniqueN(data[[y]]) > 2) && statistic == 'bothRatios') {
+    #na.rm should be safe, since x and y axes will later have NA removed anyhow in the plot.data parent class
+    if ((data.table::uniqueN(data[[x]], na.rm = TRUE) > 2 || data.table::uniqueN(data[[y]], na.rm = TRUE) > 2) && statistic == 'bothRatios') {
       stop('Odds ratio and relative risk can only be calculated for 2x2 contingency tables. Please use statistic `chiSq` instead.')
     }
   } else {
-    if (data.table::uniqueN(data[[x]]) > 2 || data.table::uniqueN(data[[y]]) > 2) {
+    if (data.table::uniqueN(data[[x]], na.rm = TRUE) > 2 || data.table::uniqueN(data[[y]], na.rm = TRUE) > 2) {
       statistic <- 'chiSq'
     } else {
       statistic <- 'bothRatios'

--- a/tests/testthat/test-mosaic.R
+++ b/tests/testthat/test-mosaic.R
@@ -387,6 +387,7 @@ test_that("mosaic.dt() returns correct information about missing data", {
   df$entity.panel[sample(1:100, 10, replace=F)] <- NA
   
   dt <- mosaic.dt(df, map)
+  expect_equal(names(statsTable(dt)),c('oddsratio', 'relativerisk', 'orInterval', 'rrInterval', 'pvalue', 'entity.panel'))
   completecasestable <- completeCasesTable(dt)
   # Each entry should equal NROW(df) - 10
   expect_equal(all(completecasestable$completeCases == nrow(df)-10), TRUE)


### PR DESCRIPTION
resolves #87 by:

1. excluding NA from the count of unique values when determining which statistic to use for mosaic plots/ validating requested statistics. i think this is fine bc the NA values are always removed from the axes vars later in the plot.data parent class anyhow, which are whats used to determine the right stats.
2. add a test for the condition. 