### PR TITLE
Outliers need to be arrays always

### DIFF
--- a/R/group.R
+++ b/R/group.R
@@ -121,9 +121,18 @@ groupOutliers <- function(data, x = NULL, y, group = NULL, panel = NULL, collaps
 
   dt$outliers <- lapply(dt$outliers, FUN=function(x){if (is.null(x)) x <- list(); return(x)})
 
+  # Wrap single outliers in a list if not already.
+  if (is.null(group) && is.null(panel)) {
+    dt$outliers <- lapply(dt$outliers, FUN=function(x){
+      if (length(x)==1 & typeof(x)=='double') { x <- list(x)}
+      return(x)
+      })
+  }
+  
   if (collapse) {
     dt <- collapseByGroup(dt, group, panel)
   }
+  
   
   indexCols <- c(panel, group)
   setkeyv(dt, indexCols)

--- a/R/group.R
+++ b/R/group.R
@@ -121,12 +121,9 @@ groupOutliers <- function(data, x = NULL, y, group = NULL, panel = NULL, collaps
 
   dt$outliers <- lapply(dt$outliers, FUN=function(x){if (is.null(x)) x <- list(); return(x)})
 
-  # Wrap single outliers in a list if not already.
-  if (is.null(group) && is.null(panel)) {
-    dt$outliers <- lapply(dt$outliers, FUN=function(x){
-      if (length(x)==1 & typeof(x)=='double') { x <- list(x)}
-      return(x)
-      })
+  # Ensure single outliers in a list if not already.
+  if (NROW(dt) == 1 && length(dt$outliers[[1]]) == 1) {
+        dt$outliers[[1]] <- list(dt$outliers[[1]])
   }
   
   if (collapse) {

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -235,6 +235,14 @@ test_that("box.dt() returns an appropriately sized data.table", {
   expect_equal(names(dt),c('panel', 'label', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'rawData', 'mean'))
   expect_equal(class(dt$panel), 'character')
   
+  # A single outlier
+  df <- data.frame('entity.x' = c('group1'), 'entity.y'=c(35.1, 34.2, 36.2, 90.2))
+  map <- data.frame('id' = c('entity.y', 'entity.x'), 'plotRef' = c('yAxisVariable', 'xAxisVariable'), 'dataType' = c('NUMBER', 'STRING'), 'dataShape' = c('CONTINUOUS', 'CATEGORICAL'), stringsAsFactors=FALSE)
+  dt <- box.dt(df, map, 'outliers', FALSE, computeStats = T)
+  expect_equal(names(dt),c('label', 'min', 'q1', 'median', 'q3', 'max', 'lowerfence', 'upperfence', 'outliers'))
+  expect_equal(class(dt$label[[1]]), 'character')
+  expect_equal(class(dt$min[[1]]), 'numeric')
+  expect_equal(class(dt$outliers[[1]]), 'list')
 })
 
 test_that("box.dt() accepts listVars for both the x axis and facet vars", {  


### PR DESCRIPTION
Addresses #96 

This PR enforces that outliers are always returned as arrays. The only change needed was for the special case of 
- one x tick, no overlay or facets, and one outlier

Additionally I tested 
- one x tick but many outliers, no overlay or facet
- one x tick, many outliers, with overlay
- no overlay or facet, one row
- multiple x values but some have only 1 outlier
and all worked fine in the original code. 

## Testing
Added a new test for a single outlier on a single x tick.
Tested original variable pair with new code
<img width="1350" alt="Screen Shot 2021-10-04 at 10 32 17 AM" src="https://user-images.githubusercontent.com/11710234/135870332-26bc5883-4091-487e-af90-9b9ced64a428.png">
:
