### PR TITLE
Fix/88/reinstate data shape

### DIFF
--- a/R/class-plotdata-bar.R
+++ b/R/class-plotdata-bar.R
@@ -65,28 +65,6 @@ newBarPD <- function(.dt = data.table::data.table(),
 }
 
 validateBarPD <- function(.bar, verbose) {
-#  xAxisVariable <- attr(.bar, 'xAxisVariable')
-#  if (!xAxisVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#    stop('The independent axis must be binary, ordinal or categorical for barplot.')
-#  }
-#  overlayVariable <- attr(.bar, 'overlayVariable')
-#  if (!is.null(overlayVariable)) {
-#    if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The overlay variable must be binary, ordinal or categorical.')
-#    }
-#  }
-#  facetVariable1 <- attr(.bar, 'facetVariable1')
-#  if (!is.null(facetVariable1)) {
-#    if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The first facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
-#  facetVariable2 <- attr(.bar, 'facetVariable2')
-#  if (!is.null(facetVariable2)) {
-#    if (!facetVariable2$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The second facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
   veupathUtils::logWithTime('Barplot request has been validated!', verbose)
 
   return(.bar)

--- a/R/class-plotdata-beeswarm.R
+++ b/R/class-plotdata-beeswarm.R
@@ -89,32 +89,10 @@ newBeeswarmPD <- function(.dt = data.table::data.table(),
 }
 
 validateBeeswarmPD <- function(.beeswarm, verbose) {
-  xAxisVariable <- attr(.beeswarm, 'xAxisVariable')
-  #if (!xAxisVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #  stop('The independent axis must be binary, ordinal or categorical for beeswarm.')
-  #}
   yAxisVariable <- attr(.beeswarm, 'yAxisVariable')
-  if (!yAxisVariable$dataType %in% c('NUMBER')) {
+  if (!yAxisVariable$dataType %in% c('NUMBER', 'INTEGER')) {
     stop('The dependent axis must be of type number for beeswarm.')
   }
-  overlayVariable <- attr(.beeswarm, 'overlayVariable')
-  #if (!is.null(overlayVariable)) {
-  #  if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #    stop('The overlay variable must be binary, ordinal or categorical.')
-  #  }
-  #}
-  facetVariable1 <- attr(.beeswarm, 'facetVariable1')
-  #if (!is.null(facetVariable1)) {
-  #  if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #    stop('The first facet variable must be binary, ordinal or categorical.')
-  #  }
-  #}
-  facetVariable2 <- attr(.beeswarm, 'facetVariable2')
-  #if (!is.null(facetVariable2)) {
-  #  if (!facetVariable2$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #    stop('The second facet variable must be binary, ordinal or categorical.')
-  #  }
-  #}
   logWithTime('Beeswarm request has been validated!', verbose)
 
   return(.beeswarm)

--- a/R/class-plotdata-box.R
+++ b/R/class-plotdata-box.R
@@ -131,32 +131,10 @@ newBoxPD <- function(.dt = data.table::data.table(),
 }
 
 validateBoxPD <- function(.box, verbose) {
-  xAxisVariable <- attr(.box, 'xAxisVariable')
-  #if (!xAxisVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #  stop('The independent axis must be binary, ordinal or categorical for boxplot.')
-  #}
   yAxisVariable <- attr(.box, 'yAxisVariable')
   if (!yAxisVariable$dataType %in% c('NUMBER', 'INTEGER')) {
     stop('The dependent axis must be of type number or integer for boxplot.')
   }
-  overlayVariable <- attr(.box, 'overlayVariable')
-  #if (!is.null(overlayVariable)) {
-  #  if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #    stop('The overlay variable must be binary, ordinal or categorical.')
-  #  }
-  #}
-  facetVariable1 <- attr(.box, 'facetVariable1')
-  #if (!is.null(facetVariable1)) {
-  #  if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #    stop('The first facet variable must be binary, ordinal or categorical.')
-  #  }
-  #}
-  facetVariable2 <- attr(.box, 'facetVariable2')
-  #if (!is.null(facetVariable2)) {
-  #  if (!facetVariable2$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-  #    stop('The second facet variable must be binary, ordinal or categorical.')
-  #  }
-  #}
   veupathUtils::logWithTime('Boxplot request has been validated!', verbose)
 
   return(.box)

--- a/R/class-plotdata-histogram.R
+++ b/R/class-plotdata-histogram.R
@@ -193,28 +193,10 @@ validateHistogramPD <- function(.histo, verbose) {
   stopifnot(validateBinSlider(binSlider))
   viewport <- attr(.histo, 'viewport')
   stopifnot(validateViewport(viewport))
-#  xAxisVariable <- attr(.histo, 'xAxisVariable')
-#  if (!xAxisVariable$dataShape == 'CONTINUOUS') {
-#    stop('The independent axis must be continuous for a histogram.')
-#  }
-#  overlayVariable <- attr(.histo, 'overlayVariable')
-#  if (!is.null(overlayVariable)) {
-#    if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The overlay variable must be binary, ordinal or categorical.')
-#    }
-#  }
-#  facetVariable1 <- attr(.histo, 'facetVariable1')
-#  if (!is.null(facetVariable1)) {
-#    if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The first facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
-#  facetVariable2 <- attr(.histo, 'facetVariable2')
-#  if (!is.null(facetVariable2)) {
-#    if (!facetVariable2$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The second facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
+  xAxisVariable <- attr(.histo, 'xAxisVariable')
+  if (!xAxisVariable$dataShape == 'CONTINUOUS') {
+    stop('The independent axis must be continuous for a histogram.')
+  }
   binWidth <- attr(.histo, 'binWidth')
   if (!is.null(binWidth)) {
     if (xAxisVariable$dataType == 'DATE' && !is.character(binWidth)) {

--- a/R/class-plotdata-line.R
+++ b/R/class-plotdata-line.R
@@ -85,32 +85,10 @@ newLinePD <- function(.dt = data.table::data.table(),
 }
 
 validateLinePD <- function(.line, verbose) {
-#  xAxisVariable <- attr(.line, 'xAxisVariable')
-#  if (!xAxisVariable$dataShape %in% c('CONTINUOUS','ORDINAL')) {
-#    stop('The independent axis must be continuous or ordinal for lineplot.')
-#  }
-#  yAxisVariable <- attr(.line, 'yAxisVariable')
-#  if (!yAxisVariable$dataShape %in% c('CONTINUOUS')) {
-#    stop('The dependent axis must be continuous for lineplot.')
-#  }
-#  overlayVariable <- attr(.line, 'overlayVariable')
-#  if (!is.null(overlayVariable)) {
-#    if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL', 'CONTINUOUS')) {
-#      stop('The overlay variable must be binary, ordinal, categorical, or continuous.')
-#    }
-#  }
-#  facetVariable1 <- attr(.line, 'facetVariable1')
-#  if (!is.null(facetVariable1)) {
-#    if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The first facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
-#  facetVariable2 <- attr(.line, 'facetVariable2')
-#  if (!is.null(facetVariable2)) {
-#    if (!facetVariable2$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The second facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
+  xAxisVariable <- attr(.line, 'xAxisVariable')
+  if (!xAxisVariable$dataShape %in% c('CONTINUOUS','ORDINAL')) {
+    stop('The independent axis must be continuous or ordinal for lineplot.')
+  }
   veupathUtils::logWithTime('Line plot request has been validated!', verbose)
 
   return(.line)

--- a/R/class-plotdata-mosaic.R
+++ b/R/class-plotdata-mosaic.R
@@ -62,26 +62,6 @@ newMosaicPD <- function(.dt = data.table::data.table(),
 }
 
 validateMosaicPD <- function(.mosaic, verbose) {
-#  xAxisVariable <- attr(.mosaic, 'xAxisVariable')
-#  if (!xAxisVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#    stop('The independent axis must be binary, ordinal or categorical for mosaic.')
-#  }
-#  yAxisVariable <- attr(.mosaic, 'yAxisVariable')
-#  if (!yAxisVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#    stop('The dependent axis must be binary, ordinal or categorical for mosaic.')
-#  }
-#  facetVariable1 <- attr(.mosaic, 'facetVariable1')
-#  if (!is.null(facetVariable1)) {
-#    if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The first facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
-#  facetVariable2 <- attr(.mosaic, 'facetVariable2')
-#  if (!is.null(facetVariable2)) {
-#    if (!facetVariable2$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The second facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
   veupathUtils::logWithTime('Mosaic plot request has been validated!', verbose)
 
   return(.mosaic)

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -52,13 +52,13 @@ newScatterPD <- function(.dt = data.table::data.table(),
   group <- veupathUtils::toColNameOrNull(attr$overlayVariable)
   panel <- findPanelColName(attr$facetVariable1, attr$facetVariable2)
 
-  #if (identical(attr$overlayVariable$dataShape,'CONTINUOUS')) {
-  #  series <- collapseByGroup(.pd, group = NULL, panel)
-  #  data.table::setnames(series, c(panel, 'seriesX', 'seriesY', 'seriesGradientColorscale'))
-  #} else {
+  if (identical(attr$overlayVariable$dataShape,'CONTINUOUS')) {
+    series <- collapseByGroup(.pd, group = NULL, panel)
+    data.table::setnames(series, c(panel, 'seriesX', 'seriesY', 'seriesGradientColorscale'))
+  } else {
     series <- collapseByGroup(.pd, group, panel)
     data.table::setnames(series, c(group, panel, 'seriesX', 'seriesY'))
-  #}
+  }
  
   if (attr$xAxisVariable$dataType == 'DATE') {
     series$seriesX <- lapply(series$seriesX, format, '%Y-%m-%d')
@@ -115,32 +115,14 @@ newScatterPD <- function(.dt = data.table::data.table(),
 }
 
 validateScatterPD <- function(.scatter, verbose) {
-#  xAxisVariable <- attr(.scatter, 'xAxisVariable')
-#  if (!xAxisVariable$dataShape %in% c('CONTINUOUS','ORDINAL')) {
-#    stop('The independent axis must be continuous or ordinal for scatterplot.')
-#  }
-#  yAxisVariable <- attr(.scatter, 'yAxisVariable')
-#  if (!yAxisVariable$dataShape %in% c('CONTINUOUS')) {
-#    stop('The dependent axis must be continuous for scatterplot.')
-#  }
-#  overlayVariable <- attr(.scatter, 'overlayVariable')
-#  if (!is.null(overlayVariable)) {
-#    if (!overlayVariable$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL', 'CONTINUOUS')) {
-#      stop('The overlay variable must be binary, ordinal, categorical, or continuous.')
-#    }
-#  }
-#  facetVariable1 <- attr(.scatter, 'facetVariable1')
-#  if (!is.null(facetVariable1)) {
-#    if (!facetVariable1$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The first facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
-#  facetVariable2 <- attr(.scatter, 'facetVariable2')
-#  if (!is.null(facetVariable2)) {
-#    if (!facetVariable2$dataShape %in% c('BINARY', 'ORDINAL', 'CATEGORICAL')) {
-#      stop('The second facet variable must be binary, ordinal or categorical.')
-#    }
-#  }
+  xAxisVariable <- attr(.scatter, 'xAxisVariable')
+  if (!xAxisVariable$dataShape %in% c('CONTINUOUS')) {
+    stop('The independent axis must be continuous for scatterplot.')
+  }
+  yAxisVariable <- attr(.scatter, 'yAxisVariable')
+  if (!yAxisVariable$dataShape %in% c('CONTINUOUS')) {
+    stop('The dependent axis must be continuous for scatterplot.')
+  }
   veupathUtils::logWithTime('Scatter plot request has been validated!', verbose)
 
   return(.scatter)
@@ -265,9 +247,9 @@ scattergl.dt <- function(data,
   } 
   overlayVariable <- plotRefMapToList(map, 'overlayVariable')
   if (!is.null(overlayVariable$variableId) & !identical(listVarPlotRef, 'overlayVariable')) {
-    #if (overlayVariable$dataShape == 'CONTINUOUS' & value != 'raw') {
-    #  stop('Continuous overlay variables cannot be used with trend lines.')
-    #}
+    if (overlayVariable$dataShape == 'CONTINUOUS' & value != 'raw') {
+      stop('Continuous overlay variables cannot be used with trend lines.')
+    }
   }
   facetVariable1 <- plotRefMapToList(map, 'facetVariable1')
   facetVariable2 <- plotRefMapToList(map, 'facetVariable2')

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -45,8 +45,7 @@ addStrataVariableDetails <- function(.pd) {
   # !!!!! work off a copy while writing json
   # since we have two exported fxns, dont want calling one changing the result of the other
   if (!is.null(group)) {
-    #if (!identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS') & (group %in% names(.pd))) {
-    if (group %in% names(.pd)) {
+    if (!identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS') & (group %in% names(.pd))) {
       names(.pd)[names(.pd) == group] <- 'overlayVariableDetails'
       .pd$overlayVariableDetails <- lapply(.pd$overlayVariableDetails, makeVariableDetails, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId, namedAttrList$overlayVariable$displayLabel)
       if (nrow(.pd) == 1) { .pd$overlayVariableDetails <- list(list(.pd$overlayVariableDetails)) }
@@ -138,9 +137,9 @@ getJSON <- function(.pd, evilMode) {
   
   .pd <- addStrataVariableDetails(.pd)
   # If overlay is continuous, handle similarly to x, y, z vars.
-  #if ('overlayVariable' %in% names(namedAttrList) & identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS')) {
-  #  namedAttrList$overlayVariableDetails <- makeVariableDetails(NULL, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId, namedAttrList$overlayVariable$displayLabel)
-  #}
+  if ('overlayVariable' %in% names(namedAttrList) & identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS')) {
+    namedAttrList$overlayVariableDetails <- makeVariableDetails(NULL, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId, namedAttrList$overlayVariable$displayLabel)
+  }
   
   namedAttrList$facetVariable1 <- NULL
   namedAttrList$facetVariable2 <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,6 +66,8 @@ plotRefMapToList <- function(map, plotRef) {
 #' @importFrom lubridate is.Date
 #' @importFrom lubridate as_date
 updateType <- function(x, xType, xShape='') {
+  # once forceStringType is fully implemented we wont need the dataShape check here
+  # all numbers will truly be numbers. not sure when thatll happen though.
   if (xType %in% c('NUMBER', 'INTEGER') & xShape != 'CATEGORICAL' & !is.numeric(x)) { x <- as.numeric(x) }
   if (xType %in% c('NUMBER', 'INTEGER') & xShape == 'CATEGORICAL' & !is.character(x)) { x <- as.character(x) }
   if (xType == 'DATE' & !lubridate::is.Date(x)) { x <- lubridate::as_date(x) }

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -247,36 +247,35 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(nrow(dt),1)
   expect_equal(names(dt),c('densityX', 'densityY'))
 
-  # Continuous overlay - temporarily disabled
-  # map <- data.frame('id' = c('entity.contC', 'entity.contB', 'entity.contA'),
-  #                   'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'),
-  #                   'dataType' = c('NUMBER', 'NUMBER', 'NUMBER'),
-  #                   'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CONTINUOUS'), stringsAsFactors=FALSE)
-  # 
-  # dt <- scattergl.dt(df, map, 'raw')
-  # expect_equal(nrow(dt), 1)
-  # expect_equal(names(dt), c('seriesX', 'seriesY', 'seriesGradientColorscale'))
-  # expect_true(identical(dt$seriesGradientColorscale[[1]], df$entity.contC))
-  # 
-  # map <- data.frame('id' = c('entity.cat3', 'entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
-  #                   'plotRef' = c('facetVariable2', 'yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
-  #                   'dataType' = c('STRING', 'NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
-  #                   'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
-  # 
-  # dt <- scattergl.dt(df, map, 'raw')
-  # expect_equal(nrow(dt), 12)
-  # expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'seriesGradientColorscale'))
-  # expect_equal(length(dt$seriesGradientColorscale[[1]]), length(dt$seriesX[[1]]))
-  # 
-  # map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
-  #                   'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
-  #                   'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
-  #                   'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
-  # 
-  # dt <- scattergl.dt(df, map, 'raw')
-  # expect_equal(nrow(dt), 4)
-  # expect_equal(names(dt), c('entity.cat4', 'seriesX', 'seriesY', 'seriesGradientColorscale'))
-  # expect_equal(length(dt$seriesGradientColorscale[[1]]), length(dt$seriesX[[1]]))
+   map <- data.frame('id' = c('entity.contC', 'entity.contB', 'entity.contA'),
+                     'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'),
+                     'dataType' = c('NUMBER', 'NUMBER', 'NUMBER'),
+                     'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CONTINUOUS'), stringsAsFactors=FALSE)
+   
+   dt <- scattergl.dt(df, map, 'raw')
+   expect_equal(nrow(dt), 1)
+   expect_equal(names(dt), c('seriesX', 'seriesY', 'seriesGradientColorscale'))
+   expect_true(identical(dt$seriesGradientColorscale[[1]], df$entity.contC))
+   
+   map <- data.frame('id' = c('entity.cat3', 'entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
+                     'plotRef' = c('facetVariable2', 'yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
+                     'dataType' = c('STRING', 'NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
+                     'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
+   
+   dt <- scattergl.dt(df, map, 'raw')
+   expect_equal(nrow(dt), 12)
+   expect_equal(names(dt), c('panel', 'seriesX', 'seriesY', 'seriesGradientColorscale'))
+   expect_equal(length(dt$seriesGradientColorscale[[1]]), length(dt$seriesX[[1]]))
+   
+   map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
+                     'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
+                     'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
+                     'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
+   
+   dt <- scattergl.dt(df, map, 'raw')
+   expect_equal(nrow(dt), 4)
+   expect_equal(names(dt), c('entity.cat4', 'seriesX', 'seriesY', 'seriesGradientColorscale'))
+   expect_equal(length(dt$seriesGradientColorscale[[1]]), length(dt$seriesX[[1]]))
 
   ## List vars
   map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.contC', 'entity.contD', 'entity.cat3'),
@@ -464,83 +463,82 @@ test_that("scattergl() returns appropriately formatted json", {
   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','cat3','cat4'))
   
   
-  #turn back on after phase 1, as part of #88
-  # map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
-  #                   'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
-  #                   'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
-  #                   'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
-  # 
-  # dt <- scattergl.dt(df, map, 'raw')
-  # outJson <- getJSON(dt, FALSE)
-  # jsonList <- jsonlite::fromJSON(outJson)
-  # 
-  # expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
-  # expect_equal(names(jsonList$scatterplot),c('data','config'))
-  # expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','seriesX','seriesY','seriesGradientColorscale'))
-  # expect_equal(names(jsonList$scatterplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value'))
-  # expect_equal(length(jsonList$scatterplot$data$facetVariableDetails), 4)
-  # expect_equal(jsonList$scatterplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
-  # expect_equal(names(jsonList$scatterplot$config),c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails','overlayVariableDetails'))
-  # expect_equal(names(jsonList$scatterplot$config$overlayVariableDetails),c('variableId','entityId'))
-  # expect_equal(jsonList$scatterplot$config$overlayVariableDetails$variableId, 'contC')
-  # expect_equal(names(jsonList$sampleSizeTable),c('facetVariableDetails','size'))
-  # expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
-  # expect_equal(jsonList$sampleSizeTable$facetVariableDetails[[1]]$variableId, 'cat4')
-  # expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
-  # expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
-  # expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC','cat4'))
+   map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
+                     'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
+                     'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
+                     'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
+   
+   dt <- scattergl.dt(df, map, 'raw')
+   outJson <- getJSON(dt, FALSE)
+   jsonList <- jsonlite::fromJSON(outJson)
+   
+   expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
+   expect_equal(names(jsonList$scatterplot),c('data','config'))
+   expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','seriesX','seriesY','seriesGradientColorscale'))
+   expect_equal(names(jsonList$scatterplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value'))
+   expect_equal(length(jsonList$scatterplot$data$facetVariableDetails), 4)
+   expect_equal(jsonList$scatterplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
+   expect_equal(names(jsonList$scatterplot$config),c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails','overlayVariableDetails'))
+   expect_equal(names(jsonList$scatterplot$config$overlayVariableDetails),c('variableId','entityId'))
+   expect_equal(jsonList$scatterplot$config$overlayVariableDetails$variableId, 'contC')
+   expect_equal(names(jsonList$sampleSizeTable),c('facetVariableDetails','size'))
+   expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+   expect_equal(jsonList$sampleSizeTable$facetVariableDetails[[1]]$variableId, 'cat4')
+   expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
+   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC','cat4'))
   
   
-  # map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
-  #                   'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
-  #                   'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
-  #                   'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), 'displayLabel' = c('yDisplay', 'xDisplay', 'panelDisplay', 'zDisplay'), stringsAsFactors=FALSE)
-  # 
-  # dt <- scattergl.dt(df, map, 'raw')
-  # outJson <- getJSON(dt, FALSE)
-  # jsonList <- jsonlite::fromJSON(outJson)
-  # 
-  # expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
-  # expect_equal(names(jsonList$scatterplot),c('data','config'))
-  # expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','seriesX','seriesY','seriesGradientColorscale'))
-  # expect_equal(names(jsonList$scatterplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value', 'displayLabel'))
-  # expect_equal(length(jsonList$scatterplot$data$facetVariableDetails), 4)
-  # expect_equal(jsonList$scatterplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
-  # expect_equal(names(jsonList$scatterplot$config),c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails','overlayVariableDetails'))
-  # expect_equal(names(jsonList$scatterplot$config$overlayVariableDetails),c('variableId','entityId', 'displayLabel'))
-  # expect_equal(jsonList$scatterplot$config$overlayVariableDetails$variableId, 'contC')
-  # expect_equal(names(jsonList$sampleSizeTable),c('facetVariableDetails','size'))
-  # expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
-  # expect_equal(jsonList$sampleSizeTable$facetVariableDetails[[1]]$variableId, 'cat4')
-  # expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
-  # expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId', 'displayLabel'))
-  # expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC','cat4'))
-  # 
-  # 
-  # map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
-  #                   'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
-  #                   'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
-  #                   'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), 'displayLabel' = c('', 'xDisplay', '', 'zDisplay'), stringsAsFactors=FALSE)
-  # 
-  # dt <- scattergl.dt(df, map, 'raw')
-  # outJson <- getJSON(dt, FALSE)
-  # jsonList <- jsonlite::fromJSON(outJson)
-  # 
-  # expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
-  # expect_equal(names(jsonList$scatterplot),c('data','config'))
-  # expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','seriesX','seriesY','seriesGradientColorscale'))
-  # expect_equal(names(jsonList$scatterplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value'))
-  # expect_equal(length(jsonList$scatterplot$data$facetVariableDetails), 4)
-  # expect_equal(jsonList$scatterplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
-  # expect_equal(names(jsonList$scatterplot$config),c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails','overlayVariableDetails'))
-  # expect_equal(names(jsonList$scatterplot$config$overlayVariableDetails),c('variableId','entityId', 'displayLabel'))
-  # expect_equal(jsonList$scatterplot$config$overlayVariableDetails$variableId, 'contC')
-  # expect_equal(names(jsonList$sampleSizeTable),c('facetVariableDetails','size'))
-  # expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
-  # expect_equal(jsonList$sampleSizeTable$facetVariableDetails[[1]]$variableId, 'cat4')
-  # expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
-  # expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId', 'displayLabel'))
-  # expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC','cat4'))
+   map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
+                     'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
+                     'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
+                     'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), 'displayLabel' = c('yDisplay', 'xDisplay', 'panelDisplay', 'zDisplay'), stringsAsFactors=FALSE)
+   
+   dt <- scattergl.dt(df, map, 'raw')
+   outJson <- getJSON(dt, FALSE)
+   jsonList <- jsonlite::fromJSON(outJson)
+   
+   expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
+   expect_equal(names(jsonList$scatterplot),c('data','config'))
+   expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','seriesX','seriesY','seriesGradientColorscale'))
+   expect_equal(names(jsonList$scatterplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value', 'displayLabel'))
+   expect_equal(length(jsonList$scatterplot$data$facetVariableDetails), 4)
+   expect_equal(jsonList$scatterplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
+   expect_equal(names(jsonList$scatterplot$config),c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails','overlayVariableDetails'))
+   expect_equal(names(jsonList$scatterplot$config$overlayVariableDetails),c('variableId','entityId', 'displayLabel'))
+   expect_equal(jsonList$scatterplot$config$overlayVariableDetails$variableId, 'contC')
+   expect_equal(names(jsonList$sampleSizeTable),c('facetVariableDetails','size'))
+   expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+   expect_equal(jsonList$sampleSizeTable$facetVariableDetails[[1]]$variableId, 'cat4')
+   expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
+   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId', 'displayLabel'))
+   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC','cat4'))
+   
+   
+   map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
+                     'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
+                     'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
+                     'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), 'displayLabel' = c('', 'xDisplay', '', 'zDisplay'), stringsAsFactors=FALSE)
+   
+   dt <- scattergl.dt(df, map, 'raw')
+   outJson <- getJSON(dt, FALSE)
+   jsonList <- jsonlite::fromJSON(outJson)
+   
+   expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
+   expect_equal(names(jsonList$scatterplot),c('data','config'))
+   expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','seriesX','seriesY','seriesGradientColorscale'))
+   expect_equal(names(jsonList$scatterplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value'))
+   expect_equal(length(jsonList$scatterplot$data$facetVariableDetails), 4)
+   expect_equal(jsonList$scatterplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
+   expect_equal(names(jsonList$scatterplot$config),c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails','overlayVariableDetails'))
+   expect_equal(names(jsonList$scatterplot$config$overlayVariableDetails),c('variableId','entityId', 'displayLabel'))
+   expect_equal(jsonList$scatterplot$config$overlayVariableDetails$variableId, 'contC')
+   expect_equal(names(jsonList$sampleSizeTable),c('facetVariableDetails','size'))
+   expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+   expect_equal(jsonList$sampleSizeTable$facetVariableDetails[[1]]$variableId, 'cat4')
+   expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
+   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId', 'displayLabel'))
+   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC','cat4'))
 
   map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.contC', 'entity.contD', 'entity.cat3'),
                     'plotRef' = c('facetVariable1', 'facetVariable1', 'facetVariable1', 'xAxisVariable', 'overlayVariable'),


### PR DESCRIPTION
resolves #88 

decided to go w the minimalist approach to constraints at this level, given we cant well anticipate what future vizs might need. continuous overlay support is back though.

there is a bit of work remaining, which i will detail in a separate issue, that can only be done once the b54 datasets are reloaded w forceStringType implemented as an annotation rather than the automagical inference of categorical numbers.