### PR TITLE
wrap single data point in single group in list for scatter to meet api

### DIFF
--- a/R/class-plotdata-line.R
+++ b/R/class-plotdata-line.R
@@ -160,6 +160,8 @@ newLinePD <- function(.dt = data.table::data.table(),
   }
 
   .pd$seriesY <- lapply(.pd$seriesY, as.character)
+  if (class(.pd$seriesY) != 'list') .pd$seriesY <- list(list(.pd$seriesY))
+
   attr$names <- names(.pd)
 
   veupathUtils::setAttrFromList(.pd, attr)

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -72,22 +72,28 @@ newScatterPD <- function(.dt = data.table::data.table(),
   } else {
     series$seriesX <- lapply(series$seriesX, as.character)
   }
+  if (class(series$seriesX) != 'list') series$seriesX <- list(list(series$seriesX))
+
   if (attr$yAxisVariable$dataType == 'DATE') {
     series$seriesY <- lapply(series$seriesY, format, '%Y-%m-%d')
   } else {
     series$seriesY <- lapply(series$seriesY, as.character)
   }
+  if (class(series$seriesY) != 'list') series$seriesY <- list(list(series$seriesY))
+
   if (identical(attr$overlayVariable$dataShape,'CONTINUOUS')) {
     if (identical(attr$overlayVariable$dataType,'DATE')) {
       series$seriesGradientColorscale <- lapply(series$seriesGradientColorscale, format, '%Y-%m-%d')
     } else {
       series$seriesGradientColorscale <- lapply(series$seriesGradientColorscale, as.character)
     }
+    if (class(series$seriesGradientColorscale) != 'list') series$seriesGradientColorscale <- list(list(series$seriesGradientColorscale))
   }
+  
   veupathUtils::logWithTime('Collected raw scatter plot data.', verbose)
 
   if (value == 'smoothedMean') {
-
+    
     smoothedMean <- groupSmoothedMean(.pd, x, y, group, panel)
     .pd <- smoothedMean
     veupathUtils::logWithTime('Calculated smoothed means.', verbose)
@@ -103,7 +109,7 @@ newScatterPD <- function(.dt = data.table::data.table(),
     veupathUtils::logWithTime('Calculated smoothed means.', verbose)
 
   } else if (value == 'bestFitLineWithRaw') {
-  
+
     bestFitLine <- groupBestFitLine(.pd, x, y, group, panel)
     if (!is.null(key(series))) {
       .pd <- merge(series, bestFitLine)

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -165,12 +165,12 @@ getJSON <- function(.pd, evilMode) {
     namedAttrList$computedVariableMetadata <- computedVariableMetadata
   }
   
-  # Fix single data points in a single group for scatterplot - should have seriesX AND seriesY columns
-  if (nrow(.pd) == 1 && 'seriesX' %in% names(.pd)) {
-    # Fix only needed when we hae excatly one data point in our one group
-    if (length(.pd$seriesX) == 1) {
-      .pd[, c('seriesX','seriesY') := list(seriesX = list(seriesX), seriesY = list(seriesY))]
-    }
+  # Fix single data points in a single group for scatterplot and line plot - should have seriesX AND seriesY columns
+  # Fix only needed when we hae excatly one data point in our one group
+  if (nrow(.pd) == 1 && 'seriesX' %in% names(.pd) && length(.pd$seriesX) == 1) {
+    # Either one (see issue 144) or both columns may be single strings not lists. 
+    if (typeof(.pd$seriesX) != 'list') .pd$seriesX <- list(list(.pd$seriesX))
+    if (typeof(.pd$seriesY) != 'list') .pd$seriesY <- list(list(.pd$seriesY))
   }
   
   outList <- list(class = list('data'=.pd, 'config'=namedAttrList))

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -165,7 +165,16 @@ getJSON <- function(.pd, evilMode) {
     namedAttrList$computedVariableMetadata <- computedVariableMetadata
   }
   
+  # Fix single data points in a single group for scatterplot - should have seriesX AND seriesY columns
+  if (nrow(.pd) == 1 && 'seriesX' %in% names(.pd)) {
+    # Fix only needed when we hae excatly one data point in our one group
+    if (length(.pd$seriesX) == 1) {
+      .pd[, c('seriesX','seriesY') := list(seriesX = list(seriesX), seriesY = list(seriesY))]
+    }
+  }
+  
   outList <- list(class = list('data'=.pd, 'config'=namedAttrList))
+
   if (!inherits(sampleSizeTable, 'function')) {
     outList$sampleSizeTable <- sampleSizeTable
   }

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -165,14 +165,6 @@ getJSON <- function(.pd, evilMode) {
     namedAttrList$computedVariableMetadata <- computedVariableMetadata
   }
   
-  # Fix single data points in a single group for scatterplot and line plot - should have seriesX AND seriesY columns
-  # Fix only needed when we hae excatly one data point in our one group
-  if (nrow(.pd) == 1 && 'seriesX' %in% names(.pd) && length(.pd$seriesX) == 1) {
-    # Either one (see issue 144) or both columns may be single strings not lists. 
-    if (typeof(.pd$seriesX) != 'list') .pd$seriesX <- list(list(.pd$seriesX))
-    if (typeof(.pd$seriesY) != 'list') .pd$seriesY <- list(list(.pd$seriesY))
-  }
-  
   outList <- list(class = list('data'=.pd, 'config'=namedAttrList))
 
   if (!inherits(sampleSizeTable, 'function')) {

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -753,6 +753,22 @@ test_that("lineplot() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(length(jsonList$completeCasesTable$variableDetails$variableId), 5)
+
+
+  # When we have only one data point and the plot has only one group, ensure seriesX and seriesY
+  # will be boxed in json
+  map <- data.frame('id' = c('entity.contB', 'entity.contA'),
+                    'plotRef' = c('yAxisVariable', 'xAxisVariable'),
+                    'dataType' = c('NUMBER', 'NUMBER'),
+                    'dataShape' = c('CONTINUOUS', 'CONTINUOUS'), stringsAsFactors=FALSE)
+  
+  df <- as.data.frame(testDF)
+
+  dt <- lineplot.dt(df, map, binWidth=100) # Will produce one point
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(typeof(jsonList$lineplot$data$seriesX), 'list')
+  expect_equal(typeof(jsonList$lineplot$data$seriesY), 'list')
 })
 
 test_that("lineplot.dt() returns correct information about missing data", {

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -677,6 +677,23 @@ test_that("scattergl() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(length(jsonList$completeCasesTable$variableDetails$variableId), 5)
+
+
+  # When we have only one data point and the plot has only one group, ensure seriesX and seriesY
+  # will be arrays
+  map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
+                    'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
+                    'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
+                    'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL', 'CONTINUOUS'), 'displayLabel' = c('yDisplay', 'xDisplay', 'panelDisplay', 'zDisplay'), stringsAsFactors=FALSE)
+  
+  df <- as.data.frame(testDF)
+  df <- df[1, ]
+
+  dt <- scattergl.dt(df, map, 'raw')
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(typeof(jsonList$scatterplot$data$seriesX), 'list')
+  expect_equal(typeof(jsonList$scatterplot$data$seriesY), 'list')
 })
 
 

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -110,6 +110,7 @@ test_that("scattergl.dt() returns plot data and config of the appropriate types"
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(class(unlist(sampleSizes$entity.cat4)), 'character')
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
+
 })
 
 test_that("scattergl.dt() returns an appropriately sized data.table", {


### PR DESCRIPTION
Resolves #135 

This PR updates `getJSON` so that it wraps scatterplot single data points of single groups in a list. This ensures that when the data is written to json in the eda it matches the api (array of strings, not a string).

Also considered:
- Does this issue affect the line plot as well? No, the line plot errs if given a single point. I'll make a separate issue.
- Is the json normal if some but not all scatterplot dt rows have a single point? Yes
- Is the json normal if there are multiple rows but all have only one data point? Yes


Testing - looks good!

<img width="1382" alt="Screen Shot 2022-04-06 at 4 36 54 PM" src="https://user-images.githubusercontent.com/11710234/162066486-0dbccede-5f24-4710-bdbb-d6d18965bc4d.png">

