### PR TITLE
handle low cardinality continuous overlay vars like categorical

### DIFF
--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -58,7 +58,7 @@ newScatterPD <- function(.dt = data.table::data.table(),
   group <- veupathUtils::toColNameOrNull(attr$overlayVariable)
   panel <- findPanelColName(attr$facetVariable1, attr$facetVariable2)
 
-  if (identical(attr$overlayVariable$dataShape,'CONTINUOUS') && useGradientColorscale) {
+  if (useGradientColorscale) {
     .pd$overlayMissingData <- is.na(.pd[[group]])
     series <- collapseByGroup(.pd, group = 'overlayMissingData', panel)
     .pd$overlayMissingData <- NULL

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -84,7 +84,7 @@ newScatterPD <- function(.dt = data.table::data.table(),
   if (class(series$seriesY) != 'list') series$seriesY <- list(list(series$seriesY))
 
 
-  if (identical(attr$overlayVariable$dataShape,'CONTINUOUS') && useGradientColorscale) {
+  if (useGradientColorscale) {
     if (identical(attr$overlayVariable$dataType,'DATE')) {
       series$seriesGradientColorscale <- lapply(series$seriesGradientColorscale, format, '%Y-%m-%d')
     } else {
@@ -268,7 +268,7 @@ scattergl.dt <- function(data,
   # Decide if we should use a gradient colorscale
   # For now the decision is handled internally. Eventually we may allow for this logic to be overridden and it can be a function arg.
   useGradientColorscale <- FALSE
-  if (!is.null(overlayVariable$variableId)) {
+  if (!is.null(overlayVariable$variableId) && !identical(collectionVariablePlotRef, 'overlayVariable')) {
     overlayVariableColumnName <- veupathUtils::toColNameOrNull(overlayVariable)
     if (identical(overlayVariable$dataShape, 'CONTINUOUS') && data.table::uniqueN(data[[overlayVariableColumnName]]) > 8) useGradientColorscale <- TRUE
   }

--- a/R/class-plotdata.R
+++ b/R/class-plotdata.R
@@ -257,7 +257,7 @@ newPlotdata <- function(.dt = data.table(),
   # If using a gradient colorscale, overlay var does not contribute to final groups
   overlayGroup <- if (useGradientColorscale) NULL else group
 
-  if (xShape != 'CONTINUOUS') {
+  if (xShape != 'CONTINUOUS' || uniqueN(.dt[[x]]) < 9) {
     .dt$dummy <- 1
     sampleSizeTable <- groupSize(.dt, x=x, y="dummy", overlayGroup, panel, collapse=F)
     .dt$dummy <- NULL

--- a/R/class-plotdata.R
+++ b/R/class-plotdata.R
@@ -56,7 +56,8 @@ newPlotdata <- function(.dt = data.table(),
                                               'dataType' = NULL,
                                               'dataShape' = NULL,
                                               'displayLabel' = NULL,
-                                              'naToZero' = NULL),                      
+                                              'naToZero' = NULL),      
+                         useGradientColorscale = FALSE,                
                          evilMode = character(),
                          collectionVariableDetails = list('inferredVariable' = NULL,
                                                'inferredVarPlotRef' = NULL,
@@ -253,8 +254,8 @@ newPlotdata <- function(.dt = data.table(),
     .dt <- .dt[complete.cases(.dt),]
   }
 
-  # If overlay is continuous, it does not contribute to final groups
-  overlayGroup <- if (identical(overlayVariable$dataShape,'CONTINUOUS')) NULL else group
+  # If using a gradient colorscale, overlay var does not contribute to final groups
+  overlayGroup <- if (useGradientColorscale) NULL else group
 
   if (xShape != 'CONTINUOUS') {
     .dt$dummy <- 1

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -36,7 +36,7 @@ addVariableDetailsToColumn <- function(.pd, variableIdColName) {
   return(.pd)
 }
 
-addStrataVariableDetails <- function(.pd) {
+addStrataVariableDetails <- function(.pd, useGradientColorscale=FALSE) {
   namedAttrList <- getPDAttributes(.pd)
   group <- veupathUtils::toColNameOrNull(namedAttrList$overlayVariable)
   facet1 <- veupathUtils::toColNameOrNull(namedAttrList$facetVariable1)
@@ -44,12 +44,9 @@ addStrataVariableDetails <- function(.pd) {
  
   # !!!!! work off a copy while writing json
   # since we have two exported fxns, dont want calling one changing the result of the other
-  if (!is.null(group)) {
-    if (!identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS') & (group %in% names(.pd))) {
-      names(.pd)[names(.pd) == group] <- 'overlayVariableDetails'
-      .pd$overlayVariableDetails <- lapply(.pd$overlayVariableDetails, makeVariableDetails, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId, namedAttrList$overlayVariable$displayLabel)
-      #if (nrow(.pd) == 1) { .pd$overlayVariableDetails <- list(list(.pd$overlayVariableDetails)) }
-    }
+  if (!is.null(group) && !useGradientColorscale && (group %in% names(.pd))) {
+    names(.pd)[names(.pd) == group] <- 'overlayVariableDetails'
+    .pd$overlayVariableDetails <- lapply(.pd$overlayVariableDetails, makeVariableDetails, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId, namedAttrList$overlayVariable$displayLabel)
   }
 
   if (!is.null(facet1) & !is.null(facet2)) {
@@ -74,13 +71,14 @@ addStrataVariableDetails <- function(.pd) {
 getJSON <- function(.pd, evilMode) {
   namedAttrList <- getPDAttributes(.pd)
   class <- attr(.pd, 'class')[1] 
+  useGradientColorscale <- ifelse(identical(namedAttrList$useGradientColorscale, TRUE), TRUE, FALSE)
 
   if ('statsTable' %in% names(namedAttrList)) {
     statsTable <- statsTable(.pd)
     namedAttrList$statsTable <- NULL
     attr <- attributes(statsTable)
     statsTable <- veupathUtils::setAttrFromList(statsTable, namedAttrList, removeExtraAttrs=F)
-    statsTable <- addStrataVariableDetails(statsTable)
+    statsTable <- addStrataVariableDetails(statsTable, useGradientColorscale)
     attr$names <- names(statsTable)
     statsTable <- veupathUtils::setAttrFromList(statsTable, attr)
     if (veupathUtils::toColNameOrNull(namedAttrList$xAxisVariable) %in% names(statsTable)) {
@@ -95,7 +93,7 @@ getJSON <- function(.pd, evilMode) {
     namedAttrList$sampleSizeTable <- NULL
     attr <- attributes(sampleSizeTable)
     sampleSizeTable <- veupathUtils::setAttrFromList(sampleSizeTable, namedAttrList, removeExtraAttrs=F)
-    sampleSizeTable <- addStrataVariableDetails(sampleSizeTable)
+    sampleSizeTable <- addStrataVariableDetails(sampleSizeTable, useGradientColorscale)
     attr$names <- names(sampleSizeTable)
     sampleSizeTable <- veupathUtils::setAttrFromList(sampleSizeTable, attr)
     if ('xAxisVariable' %in% names(namedAttrList)) {
@@ -131,11 +129,15 @@ getJSON <- function(.pd, evilMode) {
     namedAttrList$zAxisVariable <- NULL
   }
   
-  .pd <- addStrataVariableDetails(.pd)
+  .pd <- addStrataVariableDetails(.pd, useGradientColorscale)
+
   # If overlay is continuous, handle similarly to x, y, z vars.
-  if ('overlayVariable' %in% names(namedAttrList) && identical(namedAttrList$overlayVariable$dataShape, 'CONTINUOUS')) {
+  if (!is.null(namedAttrList$overlayVariable$variableId) && useGradientColorscale) {
     namedAttrList$overlayVariableDetails <- makeVariableDetails(NULL, namedAttrList$overlayVariable$variableId, namedAttrList$overlayVariable$entityId, namedAttrList$overlayVariable$displayLabel)
   }
+
+  # Remove useGradientColorscale
+  namedAttrList$useGradientColorscale <- NULL
   
   namedAttrList$facetVariable1 <- NULL
   namedAttrList$facetVariable2 <- NULL

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -97,8 +97,8 @@ getJSON <- function(.pd, evilMode) {
     attr$names <- names(sampleSizeTable)
     sampleSizeTable <- veupathUtils::setAttrFromList(sampleSizeTable, attr)
     if ('xAxisVariable' %in% names(namedAttrList)) {
-      if (namedAttrList$xAxisVariable$dataShape != "CONTINUOUS") {
-        x <- veupathUtils::toColNameOrNull(namedAttrList$xAxisVariable)
+      x <- veupathUtils::toColNameOrNull(namedAttrList$xAxisVariable)
+      if (x %in% names(sampleSizeTable)) {
         names(sampleSizeTable)[names(sampleSizeTable) == x] <- 'xVariableDetails'
         sampleSizeTable$xVariableDetails <- lapply(sampleSizeTable$xVariableDetails, makeVariableDetails, namedAttrList$xAxisVariable$variableId, namedAttrList$xAxisVariable$entityId, namedAttrList$xAxisVariable$displayLabel)
       }

--- a/tests/testthat/test-bar.R
+++ b/tests/testthat/test-bar.R
@@ -355,6 +355,54 @@ test_that("bar() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('int6', 'cat6', 'int7'))
 
+  # With a integer overlay
+  map <- data.frame('id' = c('entity.cat6', 'entity.int6', 'entity.int7'),
+                    'plotRef' = c('facetVariable1', 'xAxisVariable', 'overlayVariable'),
+                    'dataType' = c('NUMBER', 'NUMBER', 'INTEGER'),
+                    'dataShape' = c('CATEGORICAL', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
+  
+  dt <- bar.dt(df, map, value='count')
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList), c('barplot','sampleSizeTable','completeCasesTable'))
+  expect_equal(names(jsonList$barplot), c('data','config'))
+  expect_equal(names(jsonList$barplot$data), c('overlayVariableDetails','facetVariableDetails','label','value'))
+  expect_equal(names(jsonList$barplot$config), c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails'))
+  expect_equal(names(jsonList$barplot$config$xVariableDetails), c('variableId','entityId'))
+  expect_equal(jsonList$barplot$config$xVariableDetails$variableId, 'int6')
+  expect_equal(names(jsonList$sampleSizeTable), c('overlayVariableDetails','facetVariableDetails','xVariableDetails','size'))
+  expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value), 'character')
+  expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+  expect_equal(jsonList$sampleSizeTable$overlayVariableDetails$variableId[[1]], 'int7')
+  expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
+  expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+  expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('int6', 'int7', 'cat6'))
+
+  # With a number overlay (fewer than 9 values)
+  map <- data.frame('id' = c('entity.cat6', 'entity.int6', 'entity.int7'),
+                    'plotRef' = c('facetVariable1', 'xAxisVariable', 'overlayVariable'),
+                    'dataType' = c('NUMBER', 'NUMBER', 'NUMBER'),
+                    'dataShape' = c('CATEGORICAL', 'CATEGORICAL', 'CONTINUOUS'), stringsAsFactors=FALSE)
+  
+  dt <- bar.dt(df, map, value='count')
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList), c('barplot','sampleSizeTable','completeCasesTable'))
+  expect_equal(names(jsonList$barplot), c('data','config'))
+  expect_equal(names(jsonList$barplot$data), c('overlayVariableDetails','facetVariableDetails','label','value'))
+  expect_equal(names(jsonList$barplot$config), c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails'))
+  expect_equal(names(jsonList$barplot$config$xVariableDetails), c('variableId','entityId'))
+  expect_equal(jsonList$barplot$config$xVariableDetails$variableId, 'int6')
+  expect_equal(names(jsonList$sampleSizeTable), c('overlayVariableDetails','facetVariableDetails','xVariableDetails','size'))
+  expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value), 'character')
+  expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+  expect_equal(jsonList$sampleSizeTable$overlayVariableDetails$variableId[[1]], 'int7')
+  expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
+  expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+  expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('int6', 'int7', 'cat6'))
+
 })
 
 

--- a/tests/testthat/test-beeswarm.R
+++ b/tests/testthat/test-beeswarm.R
@@ -545,6 +545,29 @@ test_that("beeswarm() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(class(jsonList$beeswarm$data$label[[1]]), 'character')
+
+
+  # With continuous overlay variable (< 9 values)
+  map <- data.frame('id' = c('entity.int6', 'entity.contB', 'entity.binA'),
+                    'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'),
+                    'dataType' = c('NUMBER', 'NUMBER', 'STRING'),
+                    'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL'), stringsAsFactors=FALSE)
+
+  dt <- beeswarm.dt(df, map, 0.1, FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList), c('beeswarm','sampleSizeTable','completeCasesTable'))
+  expect_equal(names(jsonList$beeswarm), c('data','config'))
+  expect_equal(names(jsonList$beeswarm$data), c('overlayVariableDetails','label','rawData', 'jitteredValues'))
+  expect_equal(names(jsonList$beeswarm$config), c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails'))
+  expect_equal(names(jsonList$beeswarm$config$xVariableDetails), c('variableId','entityId'))
+  expect_equal(names(jsonList$sampleSizeTable), c('overlayVariableDetails','xVariableDetails','size'))
+  expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value), 'character')
+  expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
+  expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+  expect_equal(class(jsonList$beeswarm$data$label[[1]]), 'character')
+  
 })
 
 

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -784,6 +784,33 @@ test_that("box() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(names(jsonList$statsTable), c('facetVariableDetails','statistic','pvalue','parameter','method','statsError'))
   expect_equal(class(jsonList$boxplot$data$label[[1]]), 'character')
+
+
+  # With continuous overlay (< 9 values)
+  map <- data.frame('id' = c('entity.int6', 'entity.contB', 'entity.binA'),
+                    'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'),
+                    'dataType' = c('NUMBER', 'NUMBER', 'STRING'),
+                    'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL'), stringsAsFactors=FALSE)
+
+  dt <- box.dt(df, map, 'none', FALSE, computeStats = T)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList), c('boxplot','sampleSizeTable','statsTable','completeCasesTable'))
+  expect_equal(names(jsonList$boxplot), c('data','config'))
+  expect_equal(names(jsonList$boxplot$data), c('overlayVariableDetails','label','min','q1','median','q3','max','lowerfence','upperfence'))
+  expect_equal(names(jsonList$boxplot$config), c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails'))
+  expect_equal(names(jsonList$boxplot$config$xVariableDetails), c('variableId','entityId'))
+  expect_equal(names(jsonList$sampleSizeTable), c('overlayVariableDetails','xVariableDetails','size'))
+  expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value), 'character')
+  expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
+  expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+  expect_equal(names(jsonList$statsTable), c('xVariableDetails','statistic','pvalue','parameter','method','statsError'))
+  expect_equal(jsonList$statsTable$xVariableDetails$variableId[1], 'binA')
+  expect_equal(class(jsonList$statsTable$statistic), 'numeric')
+  expect_equal(class(jsonList$statsTable$statsError), 'character')
+  expect_equal(class(jsonList$boxplot$data$label[[1]]), 'character')
+
 })
 
 

--- a/tests/testthat/test-histogram.R
+++ b/tests/testthat/test-histogram.R
@@ -683,6 +683,38 @@ test_that("histogram() returns appropriately formatted json", {
   expect_equal(names(jsonList$histogram$config$xVariableDetails),c('variableId','entityId'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId', 'entityId', 'displayLabel'))
   expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+
+
+  # With continuous overlay (< 9 values)
+  map <- data.frame('id' = c('entity.int6', 'entity.contA', 'entity.cat4'), 
+                    'plotRef' = c('overlayVariable', 'xAxisVariable', 'facetVariable1'), 
+                    'dataType' = c('NUMBER', 'NUMBER', 'STRING'), 
+                    'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL'), 
+                    stringsAsFactors=FALSE)
+
+  viewport <- list('xMin'=min(df$entity.contA), 'xMax'=max(df$entity.contA))
+  binReportValue <- 'binWidth'
+
+  dt <- histogram.dt(df, map, binWidth = NULL, value='count', barmode = 'overlay', binReportValue, viewport)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList),c('histogram','sampleSizeTable', 'completeCasesTable'))
+  expect_equal(names(jsonList$histogram),c('data','config'))
+  expect_equal(names(jsonList$histogram$data),c('overlayVariableDetails','facetVariableDetails','binLabel','value','binStart','binEnd'))
+  expect_equal(names(jsonList$histogram$data$overlayVariableDetails),c('variableId','entityId','value'))
+  expect_equal(jsonList$histogram$data$overlayVariableDetails$variableId[1], 'int6')
+  expect_equal(names(jsonList$histogram$config),c('completeCasesAllVars','completeCasesAxesVars','summary','viewport','binSpec','binSlider','xVariableDetails'))  
+  expect_equal(names(jsonList$histogram$config$xVariableDetails),c('variableId','entityId'))
+  expect_equal(jsonList$histogram$config$xVariableDetails$variableId, 'contA')
+  expect_equal(names(jsonList$histogram$config$viewport),c('xMin','xMax'))
+  expect_equal(names(jsonList$histogram$config$binSlider),c('min','max','step'))
+  expect_equal(names(jsonList$histogram$config$summary),c('min','q1','median','mean','q3','max'))
+  expect_equal(names(jsonList$sampleSizeTable),c('overlayVariableDetails', 'facetVariableDetails', 'size'))
+  expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+  expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value[[1]]), 'character')
+  expect_equal(names(jsonList$completeCasesTable), c('variableDetails', 'completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId', 'entityId'))
+  expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA', 'int6', 'cat4'))
   
 })
 

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -769,6 +769,36 @@ test_that("lineplot() returns appropriately formatted json", {
   jsonList <- jsonlite::fromJSON(outJson)
   expect_equal(typeof(jsonList$lineplot$data$seriesX), 'list')
   expect_equal(typeof(jsonList$lineplot$data$seriesY), 'list')
+
+
+  # With continuous overlay (< 9 values)
+  map <- data.frame('id' = c('entity.int6', 'entity.cat5', 'entity.cat2', 'entity.cat4'), 
+                    'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable', 'facetVariable1'), 
+                    'dataType' = c('NUMBER', 'STRING', 'STRING', 'STRING'), 
+                    'dataShape' = c('CONTINUOUS', 'CATEGORICAL', 'ORDINAL', 'CATEGORICAL'), 
+                    stringsAsFactors=FALSE)
+
+  dt <- lineplot.dt(df, map, value = 'proportion', numeratorValues = c('cat5_a', 'cat5_b'), denominatorValues = c('cat5_a', 'cat5_b', 'cat5_c', 'cat5_d'))
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+
+  expect_equal(names(jsonList),c('lineplot','sampleSizeTable', 'completeCasesTable'))
+  expect_equal(names(jsonList$lineplot),c('data','config'))
+  expect_equal(names(jsonList$lineplot$data),c('overlayVariableDetails','facetVariableDetails','seriesX','seriesY', 'binSampleSize', 'errorBars'))
+  expect_equal(names(jsonList$lineplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value'))
+  expect_equal(length(jsonList$lineplot$data$facetVariableDetails), 24)
+  expect_equal(jsonList$lineplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
+  expect_equal(names(jsonList$lineplot$data$binSampleSize[[1]]), c("numeratorN","denominatorN"))
+  expect_equal(names(jsonList$lineplot$data$errorBars[[1]]), c('lowerBound', 'upperBound', 'error'))
+  expect_equal(names(jsonList$lineplot$config),c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails'))
+  expect_equal(names(jsonList$lineplot$config$xVariableDetails),c('variableId','entityId'))
+  expect_equal(jsonList$lineplot$config$xVariableDetails$variableId, 'cat2')
+  expect_equal(names(jsonList$sampleSizeTable),c('overlayVariableDetails','facetVariableDetails','xVariableDetails','size'))
+  expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+  expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value), 'character')
+  expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+  expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('cat2', 'cat5', 'int6', 'cat4'))
 })
 
 test_that("lineplot.dt() returns correct information about missing data", {

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -507,7 +507,7 @@ test_that("scattergl() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId')) 
   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','cat3','cat4'))
   
-  # Continuous overlay
+  # Continuous overlay with > 8 values
   map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.cat4', 'entity.contC'),
                     'plotRef' = c('yAxisVariable', 'xAxisVariable', 'facetVariable1', 'overlayVariable'),
                     'dataType' = c('NUMBER', 'NUMBER', 'STRING', 'NUMBER'),
@@ -584,6 +584,35 @@ test_that("scattergl() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId', 'displayLabel'))
   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC','cat4'))
+
+
+  # Continuous overlay with < 9 values
+  map <- data.frame('id' = c('entity.int6', 'entity.contB', 'entity.contA', 'entity.cat4'),
+                    'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable', 'facetVariable1'),
+                    'dataType' = c('NUMBER', 'NUMBER', 'NUMBER', 'STRING'),
+                    'dataShape' = c('CONTINUOUS', 'CONTINUOUS', 'CONTINUOUS', 'CATEGORICAL'), stringsAsFactors=FALSE)
+
+  dt <- scattergl.dt(df, map, 'smoothedMeanWithRaw')
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+
+  expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
+  expect_equal(names(jsonList$scatterplot),c('data','config'))
+  expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','overlayVariableDetails','seriesX','seriesY','smoothedMeanX','smoothedMeanY','smoothedMeanSE','smoothedMeanError'))
+  expect_equal(names(jsonList$scatterplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value'))
+  expect_equal(length(jsonList$scatterplot$data$facetVariableDetails), 24)
+  expect_equal(jsonList$scatterplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
+  expect_equal(names(jsonList$scatterplot$config),c('completeCasesAllVars','completeCasesAxesVars','xVariableDetails','yVariableDetails'))
+  expect_equal(names(jsonList$scatterplot$config$xVariableDetails),c('variableId','entityId'))
+  expect_equal(jsonList$scatterplot$config$xVariableDetails$variableId, 'contA')
+  expect_equal(jsonList$scatterplot$config$yVariableDetails$variableId, 'contB')
+  expect_equal(names(jsonList$sampleSizeTable),c('overlayVariableDetails','facetVariableDetails','size'))
+  expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+  expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value), 'character')
+  expect_equal(jsonList$sampleSizeTable$overlayVariableDetails$variableId[1], 'int6')
+  expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId')) 
+  expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','int6','cat4'))
 
   # With collection vars and computed variable metadata
   map <- data.frame('id' = c('entity.contB', 'entity.contA', 'entity.contC', 'entity.contD', 'entity.cat3'),


### PR DESCRIPTION
Resolves #134 

The solution implemented here is a combination of checking number of unique values as well as adding an attribute to the plot class. I went this route because it's most natural to find the number of unique values using the original input data table (before collapsing by group), and more funky to find the number of unique vars by the time we're in the writing json stage.



