### PR TITLE
force box labels to be strings

### DIFF
--- a/R/class-plotdata-box.R
+++ b/R/class-plotdata-box.R
@@ -57,6 +57,7 @@ newBoxPD <- function(.dt = data.table::data.table(),
   y <- veupathUtils::toColNameOrNull(attr$yAxisVariable)
   group <- veupathUtils::toColNameOrNull(attr$overlayVariable)
   panel <- findPanelColName(attr$facetVariable1, attr$facetVariable2)
+  .pd[[x]] <- as.character(.pd[[x]])
 
   summary <- groupSummary(.pd, x, y, group, panel)
   fences <- groupFences(.pd, x, y, group, panel)
@@ -129,9 +130,6 @@ newBoxPD <- function(.dt = data.table::data.table(),
   .pd <- .pd.base
   data.table::setnames(.pd, x, 'label')
 
-  .pd$label <- lapply(.pd$label, as.character)
-  if (class(.pd$label) != 'list') .pd$label <- list(list(.pd$label))
-  
   attr$names <- names(.pd)
   veupathUtils::setAttrFromList(.pd, attr)
 

--- a/R/class-plotdata-box.R
+++ b/R/class-plotdata-box.R
@@ -128,6 +128,10 @@ newBoxPD <- function(.dt = data.table::data.table(),
   
   .pd <- .pd.base
   data.table::setnames(.pd, x, 'label')
+
+  .pd$label <- lapply(.pd$label, as.character)
+  if (class(.pd$label) != 'list') .pd$label <- list(list(.pd$label))
+  
   attr$names <- names(.pd)
   veupathUtils::setAttrFromList(.pd, attr)
 

--- a/tests/testthat/test-bar.R
+++ b/tests/testthat/test-bar.R
@@ -77,6 +77,28 @@ test_that("bar.dt() returns plot data and config of the appropriate types", {
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(class(unlist(sampleSizes$panel)), 'character')
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
+
+  # With numeric x
+  map <- data.frame('id' = c('entity.cat4', 'entity.int6', 'entity.cat5'),
+                    'plotRef' = c('facetVariable2', 'xAxisVariable', 'facetVariable1'),
+                    'dataType' = c('STRING', 'NUMBER', 'STRING'),
+                    'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CATEGORICAL'), stringsAsFactors=FALSE)
+  df <- as.data.frame(testDF)
+
+  dt <- bar.dt(df, map, value='count')
+  expect_is(dt$label, 'list')
+  expect_equal(class(unlist(dt$label)), 'character')
+  expect_is(dt$value, 'list')
+  expect_equal(class(unlist(dt$value)), 'integer')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(class(namedAttrList$completeCasesAllVars),c('scalar', 'integer'))
+  expect_equal(class(namedAttrList$completeCasesAxesVars),c('scalar', 'integer')) 
+  completeCases <- completeCasesTable(dt)
+  expect_equal(class(unlist(completeCases$variableDetails)), 'character')
+  expect_equal(class(unlist(completeCases$completeCases)), 'integer')
+  sampleSizes <- sampleSizeTable(dt)
+  expect_equal(class(unlist(sampleSizes$panel)), 'character')
+  expect_equal(class(unlist(sampleSizes$size)), 'integer')
 })
 
 test_that("bar.dt() returns an appropriately sized data.table", {

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -252,7 +252,7 @@ test_that("box.dt() returns plot data and config of the appropriate types", {
   df <- testDF
   df[df$entity.int2 == 2] <- 1
 
-  dt <- box(df, map, 'none', TRUE)
+  dt <- box.dt(df, map, 'none', TRUE)
   expect_equal(class(dt$label[[1]]), 'character')
   expect_equal(class(dt$min[[1]]), 'numeric')
   expect_equal(class(dt$q1[[1]]), 'numeric')
@@ -270,7 +270,7 @@ test_that("box.dt() returns plot data and config of the appropriate types", {
   expect_equal(class(unlist(completeCases$variableDetails)), 'character')
   expect_equal(class(unlist(completeCases$completeCases)), 'integer')
   sampleSizes <- sampleSizeTable(dt)
-  expect_equal(class(unlist(sampleSizes$entity.int6)), 'integer') ## will become a string when written to json
+  expect_equal(class(unlist(sampleSizes$entity.int2)), 'numeric') ## will become a string when written to json
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
 })
 

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -139,6 +139,7 @@ test_that("box.dt() returns plot data and config of the appropriate types", {
   df <- as.data.frame(testDF)
 
   dt <- box.dt(df, map, 'none', TRUE)
+  expect_equal(class(dt$label[[1]]), 'character')
   expect_equal(class(dt$min[[1]]), 'numeric')
   expect_equal(class(dt$q1[[1]]), 'numeric')
   expect_equal(class(dt$median[[1]]), 'numeric')
@@ -160,6 +161,7 @@ test_that("box.dt() returns plot data and config of the appropriate types", {
   
   #w outliers
   dt <- box.dt(df, map, 'outliers', TRUE)
+  expect_equal(class(dt$label[[1]]), 'character')
   expect_equal(class(dt$min[[1]]), 'numeric')
   expect_equal(class(dt$q1[[1]]), 'numeric')
   expect_equal(class(dt$median[[1]]), 'numeric')
@@ -192,6 +194,7 @@ test_that("box.dt() returns plot data and config of the appropriate types", {
   df <- testDF[testDF$entity.cat3 == 'cat3_a' & testDF$entity.cat4 == 'cat4_a',]
 
   dt <- box.dt(df, map, 'none', TRUE)
+  expect_equal(class(dt$label[[1]]), 'character')
   expect_equal(class(dt$min[[1]]), 'numeric')
   expect_equal(class(dt$q1[[1]]), 'numeric')
   expect_equal(class(dt$median[[1]]), 'numeric')
@@ -209,6 +212,65 @@ test_that("box.dt() returns plot data and config of the appropriate types", {
   expect_equal(class(unlist(completeCases$completeCases)), 'integer')
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(class(unlist(sampleSizes$entity.cat4)), 'character')
+  expect_equal(class(unlist(sampleSizes$size)), 'integer')
+
+  # With numeric data for the x axis
+  map <- data.frame('id' = c('entity.cat3', 'entity.contB', 'entity.int6'),
+                    'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable'),
+                    'dataType' = c('STRING', 'NUMBER', 'NUMBER'),
+                    'dataShape' = c('CATEGORICAL', 'CONTINUOUS', 'CONTINUOUS'), stringsAsFactors=FALSE)
+
+  df <- testDF
+
+  dt <- box.dt(df, map, 'none', TRUE)
+  expect_equal(class(dt$label[[1]]), 'character')
+  expect_equal(class(dt$min[[1]]), 'numeric')
+  expect_equal(class(dt$q1[[1]]), 'numeric')
+  expect_equal(class(dt$median[[1]]), 'numeric')
+  expect_equal(class(dt$q3[[1]]), 'numeric')
+  expect_equal(class(dt$max[[1]]), 'numeric')
+  expect_equal(class(dt$lowerfence[[1]]), 'numeric')
+  expect_equal(class(dt$upperfence[[1]]), 'numeric')
+  expect_equal(class(dt$mean[[1]]), 'numeric')
+
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(class(namedAttrList$completeCasesAllVars),c('scalar', 'integer'))
+  expect_equal(class(namedAttrList$completeCasesAxesVars),c('scalar', 'integer'))
+  completeCases <- completeCasesTable(dt)
+  expect_equal(class(unlist(completeCases$variableDetails)), 'character')
+  expect_equal(class(unlist(completeCases$completeCases)), 'integer')
+  sampleSizes <- sampleSizeTable(dt)
+  expect_equal(class(unlist(sampleSizes$entity.int6)), 'integer') ## will become a string when written to json
+  expect_equal(class(unlist(sampleSizes$size)), 'integer')
+
+  # With a single numeric box
+  map <- data.frame('id' = c('entity.contB', 'entity.int2'),
+                    'plotRef' = c('yAxisVariable', 'xAxisVariable'),
+                    'dataType' = c('NUMBER', 'NUMBER'),
+                    'dataShape' = c('CONTINUOUS', 'CONTINUOUS'), stringsAsFactors=FALSE)
+
+  df <- testDF
+  df[df$entity.int2 == 2] <- 1
+
+  dt <- box(df, map, 'none', TRUE)
+  expect_equal(class(dt$label[[1]]), 'character')
+  expect_equal(class(dt$min[[1]]), 'numeric')
+  expect_equal(class(dt$q1[[1]]), 'numeric')
+  expect_equal(class(dt$median[[1]]), 'numeric')
+  expect_equal(class(dt$q3[[1]]), 'numeric')
+  expect_equal(class(dt$max[[1]]), 'numeric')
+  expect_equal(class(dt$lowerfence[[1]]), 'numeric')
+  expect_equal(class(dt$upperfence[[1]]), 'numeric')
+  expect_equal(class(dt$mean[[1]]), 'numeric')
+
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(class(namedAttrList$completeCasesAllVars),c('scalar', 'integer'))
+  expect_equal(class(namedAttrList$completeCasesAxesVars),c('scalar', 'integer'))
+  completeCases <- completeCasesTable(dt)
+  expect_equal(class(unlist(completeCases$variableDetails)), 'character')
+  expect_equal(class(unlist(completeCases$completeCases)), 'integer')
+  sampleSizes <- sampleSizeTable(dt)
+  expect_equal(class(unlist(sampleSizes$entity.int6)), 'integer') ## will become a string when written to json
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
 })
 


### PR DESCRIPTION
Resolves #158 

I fear we may have more fallout yet from allowing numeric vars in these classically categorical places...

