### PR TITLE
add option to remove NAs when calculating numBinsToBinWidth

### DIFF
--- a/R/class-plotdata-map-markers.R
+++ b/R/class-plotdata-map-markers.R
@@ -73,9 +73,9 @@ newMapMarkersPD <- function(.dt = data.table::data.table(),
         } else {
           numericBinWidth <- as.numeric(gsub("[^0-9.-]", "", binWidth))
           if (is.na(numericBinWidth)) { numericBinWidth <- 1 }
-            unit <- veupathUtils::trim(gsub("^[[:digit:]].", "", binWidth))
-            binSpec <- list('type'=jsonlite::unbox('binWidth'), 'value'=jsonlite::unbox(numericBinWidth), 'units'=jsonlite::unbox(unit))
-          }
+          unit <- veupathUtils::trim(gsub("^[[:digit:]].", "", binWidth))
+          binSpec <- list('type'=jsonlite::unbox('binWidth'), 'value'=jsonlite::unbox(numericBinWidth), 'units'=jsonlite::unbox(unit))
+        }
       } else {
         numBins <- binWidthToNumBins(.pd[[x]], binWidth)
         veupathUtils::logWithTime('Converted provided bin width to number of bins.', verbose)
@@ -250,7 +250,7 @@ mapMarkers.dt <- function(data,
   }
   if (is.null(binWidth) && xAxisVariable$dataType != 'STRING') {
     x <- veupathUtils::toColNameOrNull(xAxisVariable)
-    binWidth <- numBinsToBinWidth(data[[x]],8)
+    binWidth <- numBinsToBinWidth(data[[x]], 8, na.rm = TRUE)
   }
 
   geoAggregateVariable <- plotRefMapToList(map, 'geoAggregateVariable')

--- a/R/utils-bin.R
+++ b/R/utils-bin.R
@@ -205,10 +205,11 @@ binWidthToNumBins <- function(x, binWidth) {
 }
 
 #' @export
-numBinsToBinWidth <- function(x, numBins) UseMethod("numBinsToBinWidth")
+numBinsToBinWidth <- function(x, numBins, na.rm=FALSE) UseMethod("numBinsToBinWidth")
 
 #' @export
-numBinsToBinWidth.default <- function(x, numBins) {
+numBinsToBinWidth.default <- function(x, numBins, na.rm=FALSE) {
+  if (na.rm) x <- x[!is.na(x)]
   if (data.table::uniqueN(x) <= numBins) { return(0) }
 
   numDigits <- ifelse( avgDigits(x) > 6, 4, avgDigits(x) - 1)


### PR DESCRIPTION
Resolves #169 

@bobular was right! The NAs were causing issues with `numBinsToBinWidth`.

Currently we use this function on the xAxisVar in map markers only. We use it _before_ creating the plot.data class, so we have to handle NAs when this function is run. Because it's an axis var and this function is run so early, it made sense to simply remove the NAs.

Still, most of our functions intentionally do not remove NAs by default, hence the default value of the new `na.rm` arg is FALSE.

I expect that we'll need to use `numBinsToBinWidth` more substantially when we implement discrete gradient colormaps in all vizs. Handling binning with overlay vars is more complicated because of the no data toggle. If we turn 'no data' on for strata vars and chose a discrete gradient colormap with a continuous overlay var that included NAs, would we want to simply remove NAs? Seems likely but worth answering independently... or just not allowing evilMode at all...

Actually maybe we should just talk about this in the data viz meeting. If we have a discrete colormap created from a continuous var with NAs, we can keep doing a no data toggle in scatter bc we're changing the marker, but not in box. In box we'd end up with, say, 8 boxes colored from the discrete colormap, and one no data box in gray. The gray no data box would not be visually distinct enough from the other 8 boxes to all individuals. 