### PR TITLE
improve bin rounding logic

### DIFF
--- a/R/utils-cut.R
+++ b/R/utils-cut.R
@@ -46,9 +46,20 @@ cut_width <- function(x, width, center = NULL, boundary = NULL, closed = c("righ
   min_x <- find_origin(x_range, width, boundary)
   # Small correction factor so that we don't get an extra bin when, for
   # example, origin = 0, max(x) = 20, width = 10.
-  max_x <- max(x, na.rm = TRUE) + (1 - 1e-08) * width
+  # what's happening is that seq(0, 20, 10) = c(0,10, 20)
+  # if we do the ggplot fix we'll get c(0, 10, 20, 29.9)
+  # I think we only want that when the binWidth does not divide the range perfectly.
+  max_x <- max(x, na.rm = TRUE) # + (1 - 1e-08) * binWidth
 
-  breaks <- c(seq(min_x, max_x, width), max_x)
+  breaks <- c(seq(min_x, max_x, width))
+  if (max_x %ni% breaks) { 
+    print('I do not divide evenly')
+    max_x_with_cushion <- max_x + (1 - 1e-08) * width
+    breaks <- c(c(seq(min_x, max_x_with_cushion, width)), max_x_with_cushion)
+  } else {
+    print('i divide evenly')
+  }
+  print(breaks)
   cut(x, breaks, include.lowest = TRUE, right = (closed == "right"), ...)
 }
 

--- a/R/utils-cut.R
+++ b/R/utils-cut.R
@@ -44,20 +44,25 @@ cut_width <- function(x, width, center = NULL, boundary = NULL, closed = c("righ
 
   # Determine bins
   min_x <- find_origin(x_range, width, boundary)
-  max_x <- max(x, na.rm = TRUE) # + (1 - 1e-08) * binWidth
+  max_x <- max(x, na.rm = TRUE)
 
   breaks <- c(seq(min_x, max_x, width))
   # Round breaks *before* they go into the cut function. This way the data (not rounded)
   # will be correctly divided into the rounded bins
-  breaks <- as.numeric(formatC(0 + breaks, digits = 3, width = 1L))
+  if (all(x %% 1 == 0)) {
+    avgDigits <- 0
+  } else {
+    avgDigits <- floor(mean(stringi::stri_count_regex(as.character(x), "[[:digit:]]")))
+  }
+  breaks <- as.numeric(formatC(0 + breaks, digits = avgDigits, width = 1L))
 
   # If now, after rounded, our max bin does not include the max of the data, add another bin
   if (max(breaks) < max_x) {
-    endBin <- max(x, na.rm = TRUE) + (1 - 1e-08) * width
+    endBin <- max_x + (1 - 1e-08) * width
     breaks <- c(seq(min_x, endBin, width))
-    breaks <- c(breaks, as.numeric(formatC(0 + endBin, digits = 3, width = 1L)))  # Add a formatted last bin
+    breaks <- c(breaks, as.numeric(formatC(0 + endBin, digits = avgDigits, width = 1L)))  # Add a formatted last bin
   }
-  cut(x, breaks, include.lowest = TRUE, right = (closed == "right"), ...)
+  cut(x, breaks, include.lowest = TRUE, right = (closed == "right"), dig.lab = avgDigits, ...)
 }
 
 # Find the left side of left-most bin

--- a/R/utils-cut.R
+++ b/R/utils-cut.R
@@ -44,22 +44,19 @@ cut_width <- function(x, width, center = NULL, boundary = NULL, closed = c("righ
 
   # Determine bins
   min_x <- find_origin(x_range, width, boundary)
-  # Small correction factor so that we don't get an extra bin when, for
-  # example, origin = 0, max(x) = 20, width = 10.
-  # what's happening is that seq(0, 20, 10) = c(0,10, 20)
-  # if we do the ggplot fix we'll get c(0, 10, 20, 29.9)
-  # I think we only want that when the binWidth does not divide the range perfectly.
   max_x <- max(x, na.rm = TRUE) # + (1 - 1e-08) * binWidth
 
   breaks <- c(seq(min_x, max_x, width))
-  if (max_x %ni% breaks) { 
-    print('I do not divide evenly')
-    max_x_with_cushion <- max_x + (1 - 1e-08) * width
-    breaks <- c(c(seq(min_x, max_x_with_cushion, width)), max_x_with_cushion)
-  } else {
-    print('i divide evenly')
+  # Round breaks *before* they go into the cut function. This way the data (not rounded)
+  # will be correctly divided into the rounded bins
+  breaks <- as.numeric(formatC(0 + breaks, digits = 3, width = 1L))
+
+  # If now, after rounded, our max bin does not include the max of the data, add another bin
+  if (max(breaks) < max_x) {
+    endBin <- max(x, na.rm = TRUE) + (1 - 1e-08) * width
+    breaks <- c(seq(min_x, endBin, width))
+    breaks <- c(breaks, as.numeric(formatC(0 + endBin, digits = 3, width = 1L)))  # Add a formatted last bin
   }
-  print(breaks)
   cut(x, breaks, include.lowest = TRUE, right = (closed == "right"), ...)
 }
 

--- a/tests/testthat/test-bin.R
+++ b/tests/testthat/test-bin.R
@@ -89,3 +89,28 @@ test_that("findBinSliderValues() returns integers for integer types.", {
   expect_equal(as.numeric(binSlider$max %% 1), 0)
   expect_equal(as.numeric(binSlider$step %% 1), 0)
 })
+
+test_that("bin() adds an extra bin only when necessary due to rounding.", {
+
+  # Force rounding up. Max of contB gets rounded up so we should get exactly 7 bins if we calculate the binWidth explicitly
+  x <-  as.numeric(formatC(0 + testDF$entity.contB, digits = 3, width = 1L)) # force reasonable number of digits
+  x[1] <- 3.99999
+  binWidth <- (max(x) - min(x)) / 7
+  xRange <- list('xMin' = min(x)
+                ,'xMax' = max(x))
+
+  bins <- bin(x, binWidth, xRange, stringsAsFactors=TRUE)
+  expect_equal(length(levels(bins)), 7)
+
+  # Force rounding down at the last bin so that the max data point needs to go in an added extra bin
+  x <-  as.numeric(formatC(0 + testDF$entity.contB, digits = 3, width = 1L)) # force reasonable number of digits
+  x[1] <- 3.11111
+  binWidth <- (max(x) - min(x)) / 7
+  xRange <- list('xMin' = min(x)
+                ,'xMax' = max(x))
+
+  bins <- bin(x, binWidth, xRange, stringsAsFactors=TRUE)
+  expect_equal(length(levels(bins)), 8)
+
+
+})


### PR DESCRIPTION
Resolves #175 

Not sure if this is truly the correct fix just yet... need to test it with a backend

Here's my idea so far:
Looks like the culprit is`cut_width`, a function that was mostly taken from ggplot. When the binWidth cuts the binRange exactly, we get an extra bin. This was added in ggplot's original version of [cut_width](https://github.com/tidyverse/ggplot2/blob/775f1b49353cf1f9354e96e3bb70155e9a56af6a/R/utilities-break.r#L81-L83). However, this workaround doesn't make sense when the binWidth cuts the binRange exactly, hence my fix. 

My suspicion is that this is what's happening with the map, but i want to test the backend to be sure.
