### PR TITLE
relax stop to warning for num and denom vals not in data

### DIFF
--- a/R/class-plotdata-line.R
+++ b/R/class-plotdata-line.R
@@ -72,7 +72,8 @@ newLinePD <- function(.dt = data.table::data.table(),
       denominatorValues <- unique(.pd[[y]])
     }
     #validate num and denom values actually exist as part of the y values
-    validateValues(numeratorValues, .pd[[y]])
+    # Removing validation for numerator as part of fixing #175. If the numerator is not in the data, we get all 0s.
+    # validateValues(numeratorValues, .pd[[y]])
     validateValues(denominatorValues, .pd[[y]])
     veupathUtils::logWithTime('Numerator and denominator values have been validated.', verbose)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,7 +2,10 @@
 
 validateValues <- function(valuesOfInterest, valuesOfVariable) {
   if (any(valuesOfInterest %ni% valuesOfVariable)) {
-    stop("Values of interest do not exist as real values of the specified variable.")
+    warning("At least one value of interest does not exist as a real value in the specified variable.")
+  }
+  if (all(valuesOfInterest %ni% valuesOfVariable)) {
+    stop("No supplied values of interest exist as real values in the specified variable.")
   }
 }
 

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -942,6 +942,22 @@ test_that("lineplot.dt() returns correct information about missing data", {
   expect_equal(attr(dt, 'completeCasesAxesVars')[1] >= attr(dt, 'completeCasesAllVars')[1], TRUE)
   expect_true(attr(dt, 'completeCasesAxesVars')[1] == nrow(df) - nMissing)
 
+
+  ## When an entire part of the num or denom is missing (#157)
+  map <- data.frame('id' = c('entity.cat5', 'entity.cat3', 'entity.cat1', 'entity.cat4'),
+                    'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable', 'facetVariable1'),
+                    'dataType' = c('STRING', 'STRING', 'STRING', 'STRING'),
+                    'dataShape' = c('CATEGORICAL', 'CATEGORICAL', 'ORDINAL', 'CATEGORICAL'), stringsAsFactors=FALSE)
+
+  df <- as.data.frame(testDF)
+  df$entity.cat3[df$entity.cat3 == 'cat3_a'] <- 'cat3_b'
+
+  dt <- lineplot.dt(df, map, viewport = NULL, value = 'proportion', binWidth = NULL, numeratorValues = c('cat3_a', 'cat3_b'), denominatorValues = c('cat3_a', 'cat3_b', 'cat3_c'))
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),20)
+  expect_equal(names(dt),c('entity.cat5', 'entity.cat4', 'seriesX', 'seriesY', 'binSampleSize', 'errorBars'))
+  expect_equal(length(dt$seriesX[[1]]), length(dt$seriesY[[1]]))
+
 })
 
 test_that("lineplot.dt() always returns data ordered by seriesX/ binStart", {

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -944,19 +944,29 @@ test_that("lineplot.dt() returns correct information about missing data", {
 
 
   ## When an entire part of the num or denom is missing (#157)
-  map <- data.frame('id' = c('entity.cat5', 'entity.cat3', 'entity.cat1', 'entity.cat4'),
+  map <- data.frame('id' = c('entity.cat5', 'entity.cat2', 'entity.cat1', 'entity.cat4'),
                     'plotRef' = c('overlayVariable', 'yAxisVariable', 'xAxisVariable', 'facetVariable1'),
                     'dataType' = c('STRING', 'STRING', 'STRING', 'STRING'),
                     'dataShape' = c('CATEGORICAL', 'CATEGORICAL', 'ORDINAL', 'CATEGORICAL'), stringsAsFactors=FALSE)
 
   df <- as.data.frame(testDF)
-  df$entity.cat3[df$entity.cat3 == 'cat3_a'] <- 'cat3_b'
+  df$entity.cat2[df$entity.cat2 == 'cat2_a'] <- 'cat2_b'
 
-  dt <- lineplot.dt(df, map, viewport = NULL, value = 'proportion', binWidth = NULL, numeratorValues = c('cat3_a', 'cat3_b'), denominatorValues = c('cat3_a', 'cat3_b', 'cat3_c'))
+  # Choose as the numerator the value that is present. Should get all 1s
+  dt <- lineplot.dt(df, map, viewport = NULL, value = 'proportion', binWidth = NULL, numeratorValues = c('cat2_b'), denominatorValues = c('cat2_a','cat2_b'))
   expect_is(dt, 'data.table')
   expect_equal(nrow(dt),20)
   expect_equal(names(dt),c('entity.cat5', 'entity.cat4', 'seriesX', 'seriesY', 'binSampleSize', 'errorBars'))
   expect_equal(length(dt$seriesX[[1]]), length(dt$seriesY[[1]]))
+  expect_true(all(dt$seriesY == 1))
+
+  # Choose as the numerator the value that is NOT present. Should get all 0s
+  dt <- lineplot.dt(df, map, viewport = NULL, value = 'proportion', binWidth = NULL, numeratorValues = c('cat2_a'), denominatorValues = c('cat2_a','cat2_b'))
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt),20)
+  expect_equal(names(dt),c('entity.cat5', 'entity.cat4', 'seriesX', 'seriesY', 'binSampleSize', 'errorBars'))
+  expect_equal(length(dt$seriesX[[1]]), length(dt$seriesY[[1]]))
+  expect_true(all(dt$seriesY == 0))
 
 })
 


### PR DESCRIPTION
Resolves #157 

Recall that plot.data only sees the data after it's been subsetted. So, when we ask for a proportion with num A and denom A+B, but B has been filtered out because of subsetting or otherwise, plot.data doesn't see B at all in the data. 

So, instead of erring when the client asks for the proportion with denom = A+B, the code now prints a warning that says we did not see B in the data. 

I want to think of this solution as a temporary fix. As discussed in the EDA UX meeting today, it's very unclear to a user why they will get all 1s in the case/control example shown in the issue. Instead, we should warn the user that the intersection of values has removed an entire value from the plot. I'm not sure which service should/could do that yet. But it seems possible that whatever service does it (maybe subsetting?) could just return a flag that says oops you've subsetted out an entire variable value. Later, the warning shown to the user could involve a link to some visualization that shows the interaction of values between the variables chosen so that the user will know exactly what happened.

## Testing
- so far only added one test to ensure the the line plot doesn't fail. Before the fix it just erred, so i want to ensure we get a real object out of it.
- I'd like to integration test this before merging - will do that tomorrow!