### PR TITLE
Map `map-markers-overlay` - fix 500 for some continous variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: plot.data
 Title: Create `data.table`s of Ready to Plot Data
-Version: 3.1.2
+Version: 3.1.3
 Authors@R: 
     c(person(given = "Danielle",
            family = "Callan",

--- a/R/utils-cut.R
+++ b/R/utils-cut.R
@@ -50,19 +50,20 @@ cut_width <- function(x, width, center = NULL, boundary = NULL, closed = c("righ
   # Round breaks *before* they go into the cut function. This way the data (not rounded)
   # will be correctly divided into the rounded bins
   if (all(x %% 1 == 0)) {
-    avgDigits <- 0
+    # if all integers, use default formatting (6 significant digits)
+    requiredDigits <- -1
   } else {
-    avgDigits <- floor(mean(stringi::stri_count_regex(as.character(x), "[[:digit:]]")))
+    requiredDigits <- ceiling(median(stringi::stri_count_regex(as.character(x), "[[:digit:]]")))
   }
-  breaks <- as.numeric(formatC(0 + breaks, digits = avgDigits, width = 1L))
+  breaks <- as.numeric(formatC(0 + breaks, digits = requiredDigits, width = 1L))
 
   # If now, after rounded, our max bin does not include the max of the data, add another bin
   if (max(breaks) < max_x) {
     endBin <- max_x + (1 - 1e-08) * width
     breaks <- c(seq(min_x, endBin, width))
-    breaks <- c(breaks, as.numeric(formatC(0 + endBin, digits = avgDigits, width = 1L)))  # Add a formatted last bin
+    breaks <- c(breaks, as.numeric(formatC(0 + endBin, digits = requiredDigits, width = 1L)))  # Add a formatted last bin
   }
-  cut(x, breaks, include.lowest = TRUE, right = (closed == "right"), dig.lab = avgDigits, ...)
+  cut(x, breaks, include.lowest = TRUE, right = (closed == "right"), dig.lab = requiredDigits, ...)
 }
 
 # Find the left side of left-most bin


### PR DESCRIPTION
Fixes #179 

It turns out that all-integer variables were causing the formatC function to be called with a request for `0` significant digits. This seemed to default to 1 significant digit, which caused non-unique bins (e.g. 0, 500, 1000, 1000, 2000, 2000). The solution seems to be to use a negative value (e.g. -1).

For non-integer variables, although there was no bug here, I thought the ceiling(median(number of digits)) was a more conservative/stable approach than floor(mean(number of digits)), but open to alternatives!  I realise that median is more computationally expensive than mean (or I assume so, anyway).

I haven't added a test... (because I don't have time today to figure out the testing container) 
And I'm not sure if this will break any existing tests - do the github actions run the tests?

It is tested in the EDA though. Seems to solve the issue :+1: 