### PR TITLE
fix completeCases equals 0 for collections  when no strata selected

### DIFF
--- a/R/class-plotdata.R
+++ b/R/class-plotdata.R
@@ -162,14 +162,15 @@ newPlotdata <- function(.dt = data.table(),
     }
 
     # Calculate complete cases *before* reshaping the data
+    collectionVarColNames <- veupathUtils::toColNameOrNull(collectionVariable)
     # To count complete cases, we want to only count rows where we have at least one value in one of the collection var columns
-    completeCasesPerCollectionCol <- lapply(veupathUtils::toColNameOrNull(collectionVariable), function(collectionVar) {return(complete.cases(.dt[, ..collectionVar]))})
+    completeCasesPerCollectionCol <- lapply(collectionVarColNames, function(collectionVar) {return(complete.cases(.dt[, ..collectionVar]))})
     collectionVarDataRows <- Reduce("+", completeCasesPerCollectionCol) > 0  # Any row with val=0 means that row was missing for all vars in the collection and should be removed from the count
     # Columns not corresponding to a collection var are treated differently. Calculate their complete cases as normal
-    nonColectionVarColNames <- setdiff(c(x,y,z,group, panel), veupathUtils::toColNameOrNull(collectionVariable))
-    if (length(nonColectionVarColNames) > 0) {
-      nonCollectionVarDataRows <- complete.cases(.dt[, ..nonColectionVarColNames])
-      # Count the rows that we keep from the collection var complete cases *and* non-colection var complete cases
+    nonCollectionVarColNames <- setdiff(c(x,y,z,group, panel), collectionVarColNames)
+    if (length(nonCollectionVarColNames) > 0) {
+      nonCollectionVarDataRows <- complete.cases(.dt[, ..nonCollectionVarColNames])
+      # Count the rows that we keep from the collection var complete cases *and* non-collection var complete cases
       completeCasesAllVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows*nonCollectionVarDataRows,]))
     } else {
       # If nonCollectionVarColNames is empty, it will interfere with the multiplication above and return 0 for complete cases always.
@@ -187,7 +188,7 @@ newPlotdata <- function(.dt = data.table(),
     }
 
     # Reshape data
-    .dt <- data.table::melt(.dt, measure.vars = veupathUtils::toColNameOrNull(collectionVariable),
+    .dt <- data.table::melt(.dt, measure.vars = collectionVarColNames,
                         variable.factor = FALSE,
                         variable.name= variable.name,
                         value.name=value.name)

--- a/R/class-plotdata.R
+++ b/R/class-plotdata.R
@@ -167,9 +167,16 @@ newPlotdata <- function(.dt = data.table(),
     collectionVarDataRows <- Reduce("+", completeCasesPerCollectionCol) > 0  # Any row with val=0 means that row was missing for all vars in the collection and should be removed from the count
     # Columns not corresponding to a collection var are treated differently. Calculate their complete cases as normal
     nonColectionVarColNames <- setdiff(c(x,y,z,group, panel), veupathUtils::toColNameOrNull(collectionVariable))
-    nonCollectionVarDataRows <- complete.cases(.dt[, ..nonColectionVarColNames])
-    # Count the rows that we keep from the collection var complete cases *and* non-colection var complete cases
-    completeCasesAllVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows*nonCollectionVarDataRows,]))
+    if (length(nonColectionVarColNames) > 0) {
+      nonCollectionVarDataRows <- complete.cases(.dt[, ..nonColectionVarColNames])
+      # Count the rows that we keep from the collection var complete cases *and* non-colection var complete cases
+      completeCasesAllVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows*nonCollectionVarDataRows,]))
+    } else {
+      # If nonCollectionVarColNames is empty, it will interfere with the multiplication above and return 0 for complete cases always.
+      # Instead, here we only use the collection vars to calculate the complete cases
+      completeCasesAllVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows]))
+    }
+
     if (collectionVariableDetails$collectionVariablePlotRef == 'xAxisVariable') {
       # Since we force the collection value to be the y variable, the whole collection includes x and y.
       completeCasesAxesVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows,]))

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -804,7 +804,6 @@ test_that("box() returns appropriately formatted json", {
   expect_equal(names(jsonList$boxplot), c('data','config'))
   expect_equal(names(jsonList$boxplot$data), c('label','min','q1','median','q3','max','lowerfence','upperfence'))
   expect_equal(names(jsonList$boxplot$config), c('completeCasesAllVars','completeCasesAxesVars','computedVariableMetadata','xVariableDetails','yVariableDetails'))
-  expect_equal(jsonList$boxplot$config$completeCasesAllVars, nrow(df))
   expect_equal(names(jsonList$boxplot$config$xVariableDetails), c('variableId','entityId'))
   expect_equal(names(jsonList$boxplot$config$yVariableDetails), c('variableId','entityId'))
   expect_equal(names(jsonList$boxplot$config$computedVariableMetadata), c('displayName', 'displayRangeMin', 'displayRangeMax','collectionVariable'))

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -776,14 +776,51 @@ test_that("box() returns appropriately formatted json", {
   expect_equal(names(jsonList$boxplot$config$computedVariableMetadata$collectionVariable), c('collectionType','collectionVariablePlotRef','collectionValuePlotRef','collectionVariableDetails'))
   expect_equal(names(jsonList$boxplot$config$computedVariableMetadata$collectionVariable$collectionVariableDetails), c('variableId','entityId'))
   expect_equal(nrow(jsonList$boxplot$config$computedVariableMetadata$collectionVariable$collectionVariableDetails), 2)
-  expect_equal(jsonList$box$config$completeCasesAllVars, nrow(df))
-  expect_equal(jsonList$box$config$completeCasesAxesVars, nrow(df))
+  expect_equal(jsonList$boxplot$config$completeCasesAllVars, nrow(df))
+  expect_equal(jsonList$boxplot$config$completeCasesAxesVars, nrow(df))
   expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value), 'character')
   expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
   expect_equal(names(jsonList$sampleSizeTable), c('overlayVariableDetails','xVariableDetails','size'))
   expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(nrow(jsonList$completeCasesTable), 3)
+  expect_equal(class(jsonList$boxplot$data$label[[1]]), 'character')
+
+  # Collection var only
+  map <- data.frame('id' = c('entity.contB', 'entity.contA'),
+                    'plotRef' = c('xAxisVariable', 'xAxisVariable'),
+                    'dataType' = c('NUMBER', 'NUMBER'),
+                    'dataShape' = c('CONTINUOUS', 'CONTINUOUS'), stringsAsFactors=FALSE)
+
+  computedVariableMetadata = list('displayName' = c('VarLabel1','VarLabel2'),
+                                  'displayRangeMin' = '0.5',
+                                  'displayRangeMax' = '1.5',
+                                  'collectionVariable' = list('collectionType' = 'abundance'))
+  
+  dt <- box.dt(df, map, 'none', FALSE, collectionVariablePlotRef = 'xAxisVariable', computedVariableMetadata = computedVariableMetadata)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList), c('boxplot','sampleSizeTable','completeCasesTable'))
+  expect_equal(names(jsonList$boxplot), c('data','config'))
+  expect_equal(names(jsonList$boxplot$data), c('label','min','q1','median','q3','max','lowerfence','upperfence'))
+  expect_equal(names(jsonList$boxplot$config), c('completeCasesAllVars','completeCasesAxesVars','computedVariableMetadata','xVariableDetails','yVariableDetails'))
+  expect_equal(jsonList$boxplot$config$completeCasesAllVars, nrow(df))
+  expect_equal(names(jsonList$boxplot$config$xVariableDetails), c('variableId','entityId'))
+  expect_equal(names(jsonList$boxplot$config$yVariableDetails), c('variableId','entityId'))
+  expect_equal(names(jsonList$boxplot$config$computedVariableMetadata), c('displayName', 'displayRangeMin', 'displayRangeMax','collectionVariable'))
+  expect_equal(jsonList$boxplot$config$computedVariableMetadata$displayRangeMin, computedVariableMetadata$displayRangeMin)
+  expect_equal(jsonList$boxplot$config$computedVariableMetadata$displayRangeMax, computedVariableMetadata$displayRangeMax)
+  expect_equal(jsonList$boxplot$config$computedVariableMetadata$displayName, computedVariableMetadata$displayName)
+  expect_equal(names(jsonList$boxplot$config$computedVariableMetadata$collectionVariable), c('collectionType','collectionVariablePlotRef','collectionValuePlotRef','collectionVariableDetails'))
+  expect_equal(names(jsonList$boxplot$config$computedVariableMetadata$collectionVariable$collectionVariableDetails), c('variableId','entityId'))
+  expect_equal(nrow(jsonList$boxplot$config$computedVariableMetadata$collectionVariable$collectionVariableDetails), 2)
+  expect_equal(jsonList$boxplot$config$completeCasesAllVars, nrow(df))
+  expect_equal(jsonList$boxplot$config$completeCasesAxesVars, nrow(df))
+  expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
+  expect_equal(names(jsonList$sampleSizeTable), c('xVariableDetails','size'))
+  expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+  expect_equal(nrow(jsonList$completeCasesTable), 2)
   expect_equal(class(jsonList$boxplot$data$label[[1]]), 'character')
   
   # Multiple vars to facet1 and computed variable metadata


### PR DESCRIPTION
Resolves #192 

When there were no strata vars chosen and the collection var took up both the x and y axes, we were returning `completeCasesAllVars = 0`, which caused the brief error message described in the issue. We ended up with `completeCasesAllVars = 0` because with only the collection var selected (so no non-collection vars selected), `nonCollectionVarDataRows` was empty, causing `collectionVarDataRows*nonCollectionVarDataRows` to be empty, and eventually we ended up with seeing 0 complete cases. 

## Testing
- Added additional test in `test-box.R` that uses only the collection variable (no non-collection vars)

