### PR TITLE
Make sample sizes and complete cases optional

### DIFF
--- a/R/class-plotdata-bar.R
+++ b/R/class-plotdata-bar.R
@@ -2,6 +2,8 @@ newBarPD <- function(.dt = data.table::data.table(),
                          variables = veupathUtils::VariableMetadataList(),
                          value = character(),
                          barmode = character(),
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -9,6 +11,8 @@ newBarPD <- function(.dt = data.table::data.table(),
 
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      verbose = verbose,
                      class = "barplot")
@@ -76,6 +80,8 @@ validateBarPD <- function(.bar, verbose) {
 #' @param variables veupathUtils VariableMetadataList
 #' @param value String indicating how to calculate y-values ('identity', 'count', 'proportion')
 #' @param barmode String indicating if bars should be grouped or stacked ('group', 'stack')
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables')
 #' @param verbose boolean indicating if timed logging is desired
 #' @examples
@@ -106,13 +112,17 @@ validateBarPD <- function(.bar, verbose) {
 #' @export
 bar.dt <- function(data, 
                    variables = variables, 
-                   value = c('count', 'identity', 'proportion'), 
-                   barmode = c('group', 'stack'), 
+                   value = c('count', 'identity', 'proportion'),
+                   barmode = c('group', 'stack'),
+                   sampleSizes = c(TRUE, FALSE),
+                   completeCases = c(TRUE, FALSE),
                    evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                    verbose = c(TRUE, FALSE)) {
 
   value <- veupathUtils::matchArg(value)
   barmode <- veupathUtils::matchArg(barmode)
+  sampleSizes <- veupathUtils::matchArg(sampleSizes)
+  completeCases <- veupathUtils::matchArg(completeCases)
   evilMode <- veupathUtils::matchArg(evilMode)
   verbose <- veupathUtils::matchArg(verbose)
 
@@ -129,11 +139,18 @@ bar.dt <- function(data,
                     variables = variables,
                     value = value,
                     barmode = barmode,
+                    sampleSizes = sampleSizes,
+                    completeCases = completeCases,
                     evilMode = evilMode,
                     verbose = verbose)
 
   .bar <- validateBarPD(.bar, verbose)
-  veupathUtils::logWithTime(paste('New barplot object created with parameters value =', value, ', barmode =', barmode, ', evilMode =', evilMode, ', verbose =', verbose), verbose)
+  veupathUtils::logWithTime(paste('New barplot object created with parameters value =', value,
+                                                                              ', barmode =', barmode,
+                                                                              ', sampleSizes = ', sampleSizes,
+                                                                              ', completeCases = ', completeCases,
+                                                                              ', evilMode =', evilMode,
+                                                                              ', verbose =', verbose), verbose)
 
   return(.bar)
 }
@@ -162,6 +179,8 @@ bar.dt <- function(data,
 #' @param variables veupathUtils VariableMetadataList
 #' @param value String indicating how to calculate y-values ('identity', 'count', 'proportion')
 #' @param barmode String indicating if bars should be grouped or stacked ('group', 'stack')
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @examples
@@ -193,14 +212,24 @@ bar.dt <- function(data,
 #' @export
 bar <- function(data, 
                 variables = variables, 
-                value = c('count', 'identity', 'proportion'), 
-                barmode = c('group', 'stack'), 
+                value = c('count', 'identity', 'proportion'),
+                barmode = c('group', 'stack'),
+                sampleSizes = c(TRUE, FALSE),
+                completeCases = c(TRUE, FALSE),
                 evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                 verbose = c(TRUE, FALSE)) {
 
   verbose <- veupathUtils::matchArg(verbose)
 
-  .bar <- bar.dt(data, variables, value, barmode, evilMode, verbose)
+  .bar <- bar.dt(data = data,
+                 variables = variables,
+                 value = value,
+                 barmode = barmode,
+                 sampleSizes = sapleSizes,
+                 completeCases = completeCases,
+                 evilMode = evilMode,
+                 verbose = verbose)
+
   outFileName <- writeJSON(.bar, evilMode, 'barplot', verbose)
 
   return(outFileName)

--- a/R/class-plotdata-beeswarm.R
+++ b/R/class-plotdata-beeswarm.R
@@ -2,6 +2,8 @@ newBeeswarmPD <- function(.dt = data.table::data.table(),
                          variables = veupathUtils::VariableMetadataList(),
                          jitter = NULL,
                          median = logical(),
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -9,6 +11,8 @@ newBeeswarmPD <- function(.dt = data.table::data.table(),
 
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      verbose = verbose,
                      class = "beeswarm")
@@ -91,6 +95,8 @@ validateBeeswarmPD <- function(.beeswarm, verbose) {
 #' @param variables veupathUtils VariableMetadataList
 #' @param jitter numeric indicating the maximum width by which to randomly offset points.
 #' @param median boolean indicating whether to return median value per group (per panel)
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return data.table plot-ready data
@@ -130,11 +136,15 @@ validateBeeswarmPD <- function(.beeswarm, verbose) {
 #' @export
 beeswarm.dt <- function(data, variables,
                    jitter = NULL, 
-                   median = c(FALSE, TRUE), 
+                   median = c(FALSE, TRUE),
+                   sampleSizes = c(TRUE, FALSE),
+                   completeCases = c(TRUE, FALSE),
                    evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                    verbose = c(TRUE, FALSE)) {
 
   median <- matchArg(median)
+  sampleSizes <- matchArg(sampleSizes)
+  completeCases <- matchArg(completeCases)
   evilMode <- matchArg(evilMode)
   verbose <- matchArg(verbose)
 
@@ -169,11 +179,18 @@ beeswarm.dt <- function(data, variables,
                     variables = variables,
                     jitter = jitter,
                     median = median,
+                    sampleSizes = sampleSizes,
+                    completeCases = completeCases,
                     evilMode = evilMode,
                     verbose = verbose)
 
   .beeswarm <- validateBeeswarmPD(.beeswarm, verbose)
-  logWithTime(paste('New beeswarm object created with parameters jitter=', jitter, ', median =', median, ', evilMode =', evilMode, ', verbose =', verbose), verbose)
+  logWithTime(paste('New beeswarm object created with parameters jitter=', jitter,
+                                                                ', median =', median,
+                                                                ', sampleSizes = ', sampleSizes,
+                                                                ', completeCases = ', completeCases,
+                                                                ', evilMode =', evilMode,
+                                                                ', verbose =', verbose), verbose)
 
   return(.beeswarm) 
 
@@ -200,6 +217,8 @@ beeswarm.dt <- function(data, variables,
 #' @param variables veupathUtils VariableMetadataList
 #' @param jitter numeric indicating the maximum width by which to randomly offset points.
 #' @param median boolean indicating whether to return median value per group (per panel)
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables')
 #' @param verbose boolean indicating if timed logging is desired
 #' @return character name of json file containing plot-ready data
@@ -239,7 +258,9 @@ beeswarm.dt <- function(data, variables,
 #' @export
 beeswarm <- function(data, variables, 
                 jitter = NULL, 
-                median = c(FALSE, TRUE), 
+                median = c(FALSE, TRUE),
+                sampleSizes = c(TRUE, FALSE),
+                completeCases = c(TRUE, FALSE),
                 evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                 verbose = c(TRUE, FALSE)) {
 
@@ -249,8 +270,11 @@ beeswarm <- function(data, variables,
                  variables = variables,
                  jitter = jitter,
                  median = median,
+                 sampleSizes = sampleSizes,
+                 completeCases = completeCases,
                  evilMode = evilMode,
                  verbose = verbose)
+
   outFileName <- writeJSON(.beeswarm, evilMode, 'beeswarm', verbose)
 
   return(outFileName)

--- a/R/class-plotdata-box.R
+++ b/R/class-plotdata-box.R
@@ -3,6 +3,8 @@ newBoxPD <- function(.dt = data.table::data.table(),
                          points = character(),
                          mean = logical(),
                          computeStats = logical(),
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -10,6 +12,8 @@ newBoxPD <- function(.dt = data.table::data.table(),
 
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      verbose = verbose,
                      class = "boxplot")
@@ -136,6 +140,8 @@ validateBoxPD <- function(.box, verbose) {
 #' @param points character vector indicating which points to return 'outliers' or 'all'
 #' @param mean boolean indicating whether to return mean value per group (per panel)
 #' @param computeStats boolean indicating whether to compute nonparametric statistical tests (across x values or group values per panel)
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' Metadata can include 'displayName', 'displayRangeMin', 'displayRangeMax', and 'collectionVariable'. Will be included as an attribute of the returned plot object.
 #' @param verbose boolean indicating if timed logging is desired
@@ -176,15 +182,19 @@ validateBoxPD <- function(.box, verbose) {
 #' @export
 
 box.dt <- function(data, variables, 
-                   points = c('outliers', 'all', 'none'), 
-                   mean = c(FALSE, TRUE), 
-                   computeStats = c(FALSE, TRUE), 
+                   points = c('outliers', 'all', 'none'),
+                   mean = c(FALSE, TRUE),
+                   computeStats = c(FALSE, TRUE),
+                   sampleSizes = c(TRUE, FALSE),
+                   completeCases = c(TRUE, FALSE),
                    evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                    verbose = c(TRUE, FALSE)) {
 
   points <- veupathUtils::matchArg(points)
   mean <- veupathUtils::matchArg(mean)
   computeStats <- veupathUtils::matchArg(computeStats)
+  sampleSizes <- veupathUtils::matchArg(sampleSizes)
+  completeCases <- veupathUtils::matchArg(completeCases)
   evilMode <- veupathUtils::matchArg(evilMode)
   verbose <- veupathUtils::matchArg(verbose)
 
@@ -219,13 +229,21 @@ box.dt <- function(data, variables,
                     points = points,
                     mean = mean,
                     computeStats = computeStats,
+                    sampleSizes = sampleSizes,
+                    completeCases = completeCases,
                     evilMode = evilMode,
                     verbose = verbose)
 
   .box <- validateBoxPD(.box, verbose)
-  veupathUtils::logWithTime(paste('New boxplot object created with parameters points =', points, ', mean =', mean, ', computeStats =', computeStats, ', evilMode =', evilMode, ', verbose =', verbose), verbose)
+  veupathUtils::logWithTime(paste('New boxplot object created with parameters points =', points,
+                                                                              ', mean =', mean,
+                                                                              ', computeStats =', computeStats,
+                                                                              ', sampleSizes = ', sampleSizes,
+                                                                              ', completeCases = ', completeCases,
+                                                                              ', evilMode =', evilMode,
+                                                                              ', verbose =', verbose), verbose)
 
-  return(.box) 
+  return(.box)
 
 }
 
@@ -252,6 +270,8 @@ box.dt <- function(data, variables,
 #' @param points character vector indicating which points to return 'outliers' or 'all'
 #' @param mean boolean indicating whether to return mean value per group (per panel)
 #' @param computeStats boolean indicating whether to compute nonparametric statistical tests (across x values or group values per panel)
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return character name of json file containing plot-ready data
@@ -292,7 +312,9 @@ box.dt <- function(data, variables,
 box <- function(data, variables, 
                 points = c('outliers', 'all', 'none'), 
                 mean = c(FALSE, TRUE), 
-                computeStats = c(FALSE, TRUE), 
+                computeStats = c(FALSE, TRUE),
+                sampleSizes = c(TRUE, FALSE),
+                completeCases = c(TRUE, FALSE),
                 evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                 verbose = c(TRUE, FALSE)) {
 
@@ -303,6 +325,8 @@ box <- function(data, variables,
                  points = points,
                  mean = mean,
                  computeStats = computeStats,
+                 sampleSizes = sampleSizes,
+                 completeCases = completeCases,
                  evilMode = evilMode,
                  verbose = verbose)
   outFileName <- writeJSON(.box, evilMode, 'boxplot', verbose)

--- a/R/class-plotdata-heatmap.R
+++ b/R/class-plotdata-heatmap.R
@@ -1,6 +1,8 @@
 newHeatmapPD <- function(.dt = data.table::data.table(),
                          variables = veupathUtils::VariableMetadataList(),
                          value = character(),
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -8,6 +10,8 @@ newHeatmapPD <- function(.dt = data.table::data.table(),
 
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      verbose = verbose,
                      class = "heatmap")
@@ -75,16 +79,22 @@ validateHeatmapPD <- function(.heatmap) {
 #' @param data data.frame to make plot-ready data for
 #' @param variables veupathUtils::VariableMetadataList
 #' @param value String indicating which of the three methods to use to calculate z-values ('collection', 'series')
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return data.table plot-ready data
 #' @export
 heatmap.dt <- function(data, variables, 
-                       value = c('series', 'collection'), 
+                       value = c('series', 'collection'),
+                       sampleSizes = c(TRUE, FALSE),
+                       completeCases = c(TRUE, FALSE),
                        evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                        verbose = c(TRUE, FALSE)) {
 
   value <- veupathUtils::matchArg(value)
+  sampleSizes <- veupathUtils::matchArg(sampleSizes)
+  completeCases <- veupathUtils::matchArg(completeCases)
   evilMode <- veupathUtils::matchArg(evilMode)
   verbose <- veupathUtils::matchArg(verbose)
 
@@ -104,11 +114,17 @@ heatmap.dt <- function(data, variables,
   .heatmap <- newHeatmapPD(.dt = data,
                             variables = variables,
                             value = value,
+                            sampleSizes = sampleSizes,
+                            completeCases = completeCases,
                             evilMode = evilMode,
                             verbose = verbose)
 
   .heatmap <- validateHeatmapPD(.heatmap, verbose)
-  veupathUtils::logWithTime(paste('New heatmap object created with parameters value =', value, ', evilMode =', evilMode, ', verbose =', verbose), verbose)
+  veupathUtils::logWithTime(paste('New heatmap object created with parameters value =', value,
+                                                                            ', sampleSizes = ', sampleSizes,
+                                                                            ', completeCases = ', completeCases,
+                                                                            ', evilMode =', evilMode,
+                                                                            ', verbose =', verbose), verbose)
 
   return(.heatmap)
 
@@ -139,16 +155,28 @@ heatmap.dt <- function(data, variables,
 #' @param data data.frame to make plot-ready data for
 #' @param variables veupathUtils VariableMetadataList
 #' @param value String indicating which of the three methods to use to calculate z-values ('collection', 'series')
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return character name of json file containing plot-ready data
 #' @export
 heatmap <- function(data, variables, 
-                    value = c('series','collection'), 
+                    value = c('series','collection'),
+                    sampleSizes = c(TRUE, FALSE),
+                    completeCases = c(TRUE, FALSE),
                     evilMode = c('noVariables', 'allVariables', 'strataVariables')) {
+
   verbose <- veupathUtils::matchArg(verbose)
  
-  .heatmap <- heatmap.dt(data, variables, value, evilMode, verbose)
+  .heatmap <- heatmap.dt(data = data,
+                         variables = variables,
+                         value = value,
+                         sampleSizes = sampleSizes,
+                         completeCases = completeCases,
+                         evilMode = evilMode,
+                         verbose = verbose)
+
   outFileName <- writeJSON(.heatmap, evilMode, 'heatmap', verbose)
 
   return(outFileName)

--- a/R/class-plotdata-histogram.R
+++ b/R/class-plotdata-histogram.R
@@ -7,6 +7,8 @@ newHistogramPD <- function(.dt = data.table::data.table(),
                          binReportValue = character(),
                          value = character(),
                          barmode = character(),
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -14,6 +16,8 @@ newHistogramPD <- function(.dt = data.table::data.table(),
 
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      verbose = verbose,
                      class = "histogram")
@@ -192,6 +196,8 @@ validateHistogramPD <- function(.histo, verbose) {
 #' @param binReportValue String indicating if number of bins or bin width used should be returned
 #' @param barmode String indicating if bars should be stacked or overlaid ('stack', 'overlay')
 #' @param viewport List of min and max values to consider as the range of data
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return data.table plot-ready data
@@ -232,12 +238,16 @@ histogram.dt <- function(data,
                          binReportValue = c('binWidth', 'numBins'),
                          barmode = c('stack', 'overlay'),
                          viewport = NULL,
+                         sampleSizes = c(TRUE, FALSE),
+                         completeCases = c(TRUE, FALSE),
                          evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                          verbose = c(TRUE, FALSE)) {
 
   value <- veupathUtils::matchArg(value)
   barmode <- veupathUtils::matchArg(barmode)
   binReportValue <- veupathUtils::matchArg(binReportValue)
+  sampleSizes <- veupathUtils::matchArg(sampleSizes)
+  completeCases <- veupathUtils::matchArg(completeCases)
   evilMode <- veupathUtils::matchArg(evilMode)
   verbose <- veupathUtils::matchArg(verbose)
 
@@ -264,11 +274,22 @@ histogram.dt <- function(data,
                            binReportValue = binReportValue,
                            value = value,
                            barmode = barmode,
+                           sampleSizes = sampleSizes,
+                           completeCases = completeCases,
                            evilMode = evilMode,
                            verbose = verbose)
 
   .histo <- validateHistogramPD(.histo, verbose)
-  veupathUtils::logWithTime(paste('New histogram object created with parameters viewport min =', viewport$xMin, ', viewport max =', viewport$xMax, ', binWidth =', binWidth, ', binReportValue =', binReportValue, ', value =', value, ', barmode =', barmode, ', evilMode =', evilMode, ', verbose =', verbose), verbose)
+  veupathUtils::logWithTime(paste('New histogram object created with parameters viewport min =', viewport$xMin,
+                                                                             ', viewport max =', viewport$xMax,
+                                                                             ', binWidth =', binWidth,
+                                                                             ', binReportValue =', binReportValue,
+                                                                             ', value =', value,
+                                                                             ', barmode =', barmode,
+                                                                             ', sampleSizes = ', sampleSizes,
+                                                                             ', completeCases = ', completeCases,
+                                                                             ', evilMode =', evilMode,
+                                                                             ', verbose =', verbose), verbose)
 
   return(.histo)
 }
@@ -297,6 +318,8 @@ histogram.dt <- function(data,
 #' @param binReportValue String indicating if number of bins or bin width used should be returned
 #' @param barmode String indicating if bars should be stacked or overlaid ('stack', 'overlay')
 #' @param viewport List of min and max values to consider as the range of data
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return character name of json file containing plot-ready data
@@ -336,12 +359,25 @@ histogram <- function(data,
                       binReportValue = c('binWidth', 'numBins'), 
                       barmode = c('stack', 'overlay'),
                       viewport = NULL,
+                      sampleSizes = c(TRUE, FALSE),
+                      completeCases = c(TRUE, FALSE),
                       evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                       verbose = c(TRUE, FALSE)) {
 
   verbose <- veupathUtils::matchArg(verbose)
 
-  .histo <- histogram.dt(data, variables, binWidth, value, binReportValue, barmode, viewport, evilMode, verbose)
+  .histo <- histogram.dt(data = data, 
+                          variables = variables,
+                          binWidth = binWidth,
+                          value = value,
+                          binReportValue = binReportValue,
+                          barmode = barmode,
+                          viewport = viewport,
+                          sampleSizes = sampleSizes,
+                          completeCases = completeCases,
+                          evilMode = evilMode,
+                          verbose = verbose)
+
   outFileName <- writeJSON(.histo, evilMode, 'histogram', verbose)
 
   return(outFileName)

--- a/R/class-plotdata-line.R
+++ b/R/class-plotdata-line.R
@@ -5,6 +5,8 @@ newLinePD <- function(.dt = data.table::data.table(),
                          binWidth,
                          value = character(),
                          errorBars = logical(),
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          numeratorValues = character(),
                          denominatorValues = character(),
@@ -14,6 +16,8 @@ newLinePD <- function(.dt = data.table::data.table(),
 
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      collectionVariableDetails = collectionVariableDetails,
                      computedVariableMetadata = computedVariableMetadata,
@@ -184,6 +188,8 @@ validateLinePD <- function(.line, verbose) {
 #' @param viewport List of min and max values to consider as the range of data
 #' @param numeratorValues character vector of values from the y-axis variable to consider the numerator
 #' @param denominatorValues character vector of values from the y-axis variable to consider the denominator
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param collectionVariablePlotRef string indicating the plotRef to be considered as a collectionVariable. 
 #' Accepted values are 'overlayVariable' and 'facetVariable1'. Required whenever a set of 
@@ -228,11 +234,15 @@ lineplot.dt <- function(data,
                          viewport = NULL,
                          numeratorValues = NULL,
                          denominatorValues = NULL,
+                         sampleSizes = c(TRUE, FALSE),
+                         completeCases = c(TRUE, FALSE),
                          evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                          verbose = c(TRUE, FALSE)) {
 
   value <- veupathUtils::matchArg(value)
   errorBars <- veupathUtils::matchArg(errorBars)
+  sampleSizes <- veupathUtils::matchArg(sampleSizes)
+  completeCases <- veupathUtils::matchArg(completeCases)
   evilMode <- veupathUtils::matchArg(evilMode) 
   verbose <- veupathUtils::matchArg(verbose)  
 
@@ -267,6 +277,8 @@ lineplot.dt <- function(data,
                             binWidth,
                             value = value,
                             errorBars = errorBars,
+                            sampleSizes = sampleSizes,
+                            completeCases = completeCases,
                             evilMode = evilMode,
                             verbose = verbose)
 
@@ -278,6 +290,8 @@ lineplot.dt <- function(data,
                                                                              ', evilMode =', evilMode, 
                                                                              ', numeratorValues = ', numeratorValues, 
                                                                              ', denominatorValues = ', denominatorValues, 
+                                                                             ', sampleSizes = ', sampleSizes,
+                                                                             ', completeCases = ', completeCases,
                                                                              ', verbose = ', verbose), verbose)
 
   return(.line)
@@ -312,6 +326,8 @@ lineplot.dt <- function(data,
 #' @param viewport List of min and max values to consider as the range of data
 #' @param numeratorValues character vector of values from the y-axis variable to consider the numerator
 #' @param denominatorValues character vector of values from the y-axis variable to consider the denominator
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param collectionVariablePlotRef string indicating the plotRef to be considered as a collectionVariable. 
 #' Accepted values are 'overlayVariable' and 'facetVariable1'. Required whenever a set of variables 
@@ -357,6 +373,8 @@ lineplot <- function(data,
                       viewport = NULL,
                       numeratorValues = NULL,
                       denominatorValues = NULL,
+                      sampleSizes = c(TRUE, FALSE),
+                      completeCases = c(TRUE, FALSE),
                       evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                       collectionVariablePlotRef = NULL,
                       computedVariableMetadata = NULL,
@@ -372,6 +390,8 @@ lineplot <- function(data,
                            viewport = viewport,
                            numeratorValues = numeratorValues,
                            denominatorValues = denominatorValues,
+                           sampleSizes = sampleSizes,
+                           completeCases = completeCases,
                            evilMode = evilMode,
                            verbose = verbose)
                            

--- a/R/class-plotdata-map-markers.R
+++ b/R/class-plotdata-map-markers.R
@@ -9,6 +9,8 @@ newMapMarkersPD <- function(.dt = data.table::data.table(),
                                                          'xMax'=NULL),
                                          'longitude'=list('left'=NULL,
                                                           'right'=NULL)),
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -16,6 +18,8 @@ newMapMarkersPD <- function(.dt = data.table::data.table(),
 
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      verbose = verbose,
                      class = "mapMarkers")
@@ -234,6 +238,8 @@ validateMapMarkersPD <- function(.map, verbose) {
 #' @param binReportValue String indicating if number of bins or bin width used should be returned
 #' @param binRange List of min and max values to bin the xAxisVariable over
 #' @param viewport List of values indicating the visible range of data
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @examples
@@ -268,11 +274,15 @@ mapMarkers.dt <- function(data,
                    value = c('count', 'proportion'),
                    binReportValue = c('binWidth', 'numBins'),
                    binRange = NULL,
-                   viewport = NULL,  
+                   viewport = NULL,
+                   sampleSizes = c(TRUE, FALSE),
+                   completeCases = c(TRUE, FALSE),
                    evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                    verbose = c(TRUE, FALSE)) {
 
   value <- veupathUtils::matchArg(value)
+  sampleSizes <- veupathUtils::matchArg(sampleSizes)
+  completeCases <- veupathUtils::matchArg(completeCases)
   evilMode <- veupathUtils::matchArg(evilMode)
   verbose <- veupathUtils::matchArg(verbose)
   binReportValue <- veupathUtils::matchArg(binReportValue)
@@ -318,11 +328,20 @@ mapMarkers.dt <- function(data,
                     binReportValue = binReportValue,
                     binRange = binRange,
                     geolocationViewport = viewport,
+                    sampleSizes = sampleSizes,
+                    completeCases = completeCases,
                     evilMode = evilMode,
                     verbose = verbose)
 
   .map <- validateMapMarkersPD(.map, verbose)
-  veupathUtils::logWithTime(paste('New mapMarkers object created with parameters value =', value, ', binWidth =', binWidth, ', binReportValue =', binReportValue, ', viewport =', viewport, ', evilMode =', evilMode, ', verbose =', verbose), verbose)
+  veupathUtils::logWithTime(paste('New mapMarkers object created with parameters value =', value,
+                                                                              ', binWidth =', binWidth,
+                                                                              ', binReportValue =', binReportValue,
+                                                                              ',viewport =', viewport,
+                                                                              ', sampleSizes = ', sampleSizes,
+                                                                              ', completeCases = ', completeCases,
+                                                                              ', evilMode =', evilMode,
+                                                                              ', verbose =', verbose), verbose)
 
   return(.map)
 }
@@ -361,6 +380,8 @@ mapMarkers.dt <- function(data,
 #' @param binReportValue String indicating if number of bins or bin width used should be returned
 #' @param binRange List of min and max values to bin the xAxisVariable over
 #' @param viewport List of values indicating the visible range of data
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @examples
@@ -397,12 +418,25 @@ mapMarkers <- function(data,
                 binReportValue = c('binWidth', 'numBins'),
                 binRange = NULL,
                 viewport = NULL,
+                sampleSizes = c(TRUE, FALSE),
+                completeCases = c(TRUE, FALSE),
                 evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                 verbose = c(TRUE, FALSE)) {
 
   verbose <- veupathUtils::matchArg(verbose)
 
-  .map <- mapMarkers.dt(data, variables, binWidth, value, binReportValue, binRange, viewport, evilMode, verbose)
+  .map <- mapMarkers.dt(data = data,
+                        variables = variables,
+                        binWidth = binWidth,
+                        value = value,
+                        binReportValue = binReportValue,
+                        binRange = binRange,
+                        viewport = viewport,
+                        sampleSizes = sampleSizes,
+                        completeCases = completeCases,
+                        evilMode = evilMode,
+                        verbose = verbose)
+
   outFileName <- writeJSON(.map, evilMode, 'mapMarkers', verbose)
 
   return(outFileName)

--- a/R/class-plotdata-mosaic.R
+++ b/R/class-plotdata-mosaic.R
@@ -3,6 +3,8 @@ newMosaicPD <- function(.dt = data.table::data.table(),
                          statistic = character(),
                          columnReferenceValue = character(),
                          rowReferenceValue = character(),
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -10,6 +12,8 @@ newMosaicPD <- function(.dt = data.table::data.table(),
 
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      verbose = verbose,
                      class = "mosaic")
@@ -73,6 +77,8 @@ validateMosaicPD <- function(.mosaic, verbose) {
 #' @param statistic String indicating which statistic to calculate. Vaid options are 'chiSq' and 'all', the second of which will return odds ratios and relative risk.
 #' @param columnReferenceValue String representing a value present in the column names of the contingency table
 #' @param rowReferenceValue String representing a value present in the row names of the contingency table
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return data.table plot-ready data
@@ -106,9 +112,13 @@ mosaic.dt <- function(data, variables,
                       statistic = NULL, 
                       columnReferenceValue = NA_character_,
                       rowReferenceValue = NA_character_,
+                      sampleSizes = c(TRUE, FALSE),
+                      completeCases = c(TRUE, FALSE),
                       evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                       verbose = c(TRUE, FALSE)) {
 
+  sampleSizes <- veupathUtils::matchArg(sampleSizes)
+  completeCases <- veupathUtils::matchArg(completeCases)
   evilMode <- veupathUtils::matchArg(evilMode)
   verbose <- veupathUtils::matchArg(verbose)
 
@@ -155,11 +165,19 @@ mosaic.dt <- function(data, variables,
                             statistic = statistic,
                             columnReferenceValue = columnReferenceValue,
                             rowReferenceValue = rowReferenceValue,
+                            sampleSizes = sampleSizes,
+                            completeCases = completeCases,
                             evilMode = evilMode,
                             verbose = verbose)
 
   .mosaic <- validateMosaicPD(.mosaic, verbose)
-  veupathUtils::logWithTime(paste('New mosaic plot object created with parameters statistic =', statistic, ', evilMode =', evilMode, ', verbose =', verbose), verbose)
+  veupathUtils::logWithTime(paste('New mosaic plot object created with parameters statistic =', statistic,
+                                                                                ', columnReferenceValues = ', columnReferenceValue,
+                                                                                ', rowReferenceValue = ', rowReferenceValue,
+                                                                                ', sampleSizes = ', sampleSizes,
+                                                                                ', completeCases = ', completeCases,
+                                                                                ', evilMode =', evilMode,
+                                                                                ', verbose =', verbose), verbose)
 
   return(.mosaic)
 }
@@ -185,6 +203,8 @@ mosaic.dt <- function(data, variables,
 #' @param statistic String indicating which statistic to calculate. Vaid options are 'chiSq' and 'all', the second of which will return odds ratios and relative risk.
 #' @param columnReferenceValue String representing a value present in the column names of the contingency table
 #' @param rowReferenceValue String representing a value present in the row names of the contingency table
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return character name of json file containing plot-ready data
@@ -218,11 +238,21 @@ mosaic <- function(data, variables,
                    statistic = NULL,
                    columnReferenceValue = NA_character_,
                    rowReferenceValue = NA_character_,
+                   sampleSizes = c(TRUE, FALSE),
+                   completeCases = c(TRUE, FALSE),
                    evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                    verbose = c(TRUE, FALSE)) {
   verbose <- veupathUtils::matchArg(verbose)
 
-  .mosaic <- mosaic.dt(data, variables, statistic, columnReferenceValue, rowReferenceValue, evilMode, verbose)
+  .mosaic <- mosaic.dt(data = data,
+                       variables = variables,
+                       statistic = statistic,
+                       columnReferenceValue = columnReferenceValue,
+                       rowReferenceValue = rowReferenceValue,
+                       sampleSizes = sampleSizes,
+                       completeCases = completeCases,
+                       evilMode = evilMode,
+                       verbose = verbose)
   outFileName <- writeJSON(.mosaic, evilMode, 'mosaic', verbose)
 
   return(outFileName)

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -2,6 +2,8 @@ newScatterPD <- function(.dt = data.table::data.table(),
                          variables = veupathUtils::VariableMetadataList(),
                          value = character(),
                          useGradientColorscale = FALSE,
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -10,6 +12,8 @@ newScatterPD <- function(.dt = data.table::data.table(),
   .pd <- newPlotdata(.dt = .dt,
                      variables = variables,
                      useGradientColorscale = useGradientColorscale,
+                     sampleSizes = sampleSizes,
+                     completeCases = completeCases,
                      evilMode = evilMode,
                      verbose = verbose,
                      class = "scatterplot")
@@ -153,6 +157,8 @@ validateScatterPD <- function(.scatter, verbose) {
 #'  or 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' 
 #' to include raw data with smoothed mean. Note only 'raw' is compatible with a continuous 
 #' overlay variable.
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return data.table plot-ready data
@@ -197,6 +203,8 @@ scattergl.dt <- function(data,
                                    'bestFitLineWithRaw', 
                                    'density', 
                                    'raw'),
+                         sampleSizes = c(TRUE, FALSE),
+                         completeCases = c(TRUE, FALSE),
                          evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                          collectionVariablePlotRef = NULL,
                          computedVariableMetadata = NULL,
@@ -204,8 +212,10 @@ scattergl.dt <- function(data,
   
   if (!inherits(variables, 'VariableMetadataList')) stop("The `variables` argument must be a VariableMetadataList object.")
   value <- veupathUtils::matchArg(value)
-  evilMode <- veupathUtils::matchArg(evilMode) 
-  verbose <- veupathUtils::matchArg(verbose)  
+  sampleSizes <- veupathUtils::matchArg(sampleSizes)
+  completeCases <- veupathUtils::matchArg(completeCases)
+  evilMode <- veupathUtils::matchArg(evilMode)
+  verbose <- veupathUtils::matchArg(verbose)
 
   if (!'data.table' %in% class(data)) {
     data.table::setDT(data)
@@ -254,6 +264,8 @@ scattergl.dt <- function(data,
                             variables = variables,
                             value = value,
                             useGradientColorscale = useGradientColorscale,
+                            sampleSizes = sampleSizes,
+                            completeCases = completeCases,
                             evilMode = evilMode,
                             verbose = verbose)
 
@@ -295,6 +307,8 @@ scattergl.dt <- function(data,
 #' @param value character indicating whether to calculate 'smoothedMean', 'bestFitLineWithRaw' or 
 #' 'density' estimates (no raw data returned), alternatively 'smoothedMeanWithRaw' to include raw 
 #' data with smoothed mean. Note only 'raw' is compatible with a continuous overlay variable.
+#' @param sampleSizes boolean indicating if sample sizes should be computed
+#' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
 #' @param verbose boolean indicating if timed logging is desired
 #' @return character name of json file containing plot-ready data
@@ -339,6 +353,8 @@ scattergl <- function(data,
                                 'bestFitLineWithRaw', 
                                 'density', 
                                 'raw'),
+                      sampleSizes = c(TRUE, FALSE),
+                      completeCases = c(TRUE, FALSE),
                       evilMode = c('noVariables', 'allVariables', 'strataVariables'),
                       verbose = c(TRUE, FALSE)) {
 
@@ -347,6 +363,8 @@ scattergl <- function(data,
   .scatter <- scattergl.dt(data,
                            variables,
                            value = value,
+                           sampleSizes = sampleSizes,
+                           completeCases = completeCases,
                            evilMode = evilMode,
                            verbose = verbose)
                            

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -270,7 +270,11 @@ scattergl.dt <- function(data,
                             verbose = verbose)
 
   .scatter <- validateScatterPD(.scatter, verbose)
-  veupathUtils::logWithTime(paste('New scatter plot object created with parameters value =', value, ', evilMode =', evilMode, ', verbose =', verbose), verbose)
+  veupathUtils::logWithTime(paste('New scatter plot object created with parameters value =', value,
+                                                                                ', sampleSizes = ', sampleSizes,
+                                                                                ', completeCases = ', completeCases,
+                                                                                ', evilMode =', evilMode,
+                                                                                ', verbose =', verbose), verbose)
 
   return(.scatter)
 }

--- a/R/class-plotdata.R
+++ b/R/class-plotdata.R
@@ -13,6 +13,8 @@ newPlotdata <- function(.dt = data.table(),
                          #make sure lat, lon, geoAgg vars are valid plot References
                          variables = NULL,    
                          useGradientColorscale = FALSE,                
+                         sampleSizes = logical(),
+                         completeCases = logical(),
                          evilMode = character(),
                          verbose = logical(),
                          ...,
@@ -52,13 +54,16 @@ newPlotdata <- function(.dt = data.table(),
     veupathUtils::logWithTime(paste('Replaced NA with 0 in the following columns: ', impute0cols), verbose)
   }
 
-  #lat and lon must be used w a geohash, so they dont need to be part of completeCases*
-  varCols <- c(x, y, z, group, facet1, facet2, geo)
-  completeCasesTable <- data.table::setDT(lapply(.dt[, ..varCols], function(a) {sum(complete.cases(a))}))
-  completeCasesTable <- data.table::transpose(completeCasesTable, keep.names = 'variableDetails')
-  data.table::setnames(completeCasesTable, 'V1', 'completeCases')
-  
-  veupathUtils::logWithTime('Determined the number of complete cases per variable.', verbose)
+  ## Calculate complete cases table if desired
+  if (completeCases) {
+    #lat and lon must be used w a geohash, so they dont need to be part of completeCases*
+    varCols <- c(x, y, z, group, facet1, facet2, geo)
+    completeCasesTable <- data.table::setDT(lapply(.dt[, ..varCols], function(a) {sum(complete.cases(a))}))
+    completeCasesTable <- data.table::transpose(completeCasesTable, keep.names = 'variableDetails')
+    data.table::setnames(completeCasesTable, 'V1', 'completeCases')
+    
+    veupathUtils::logWithTime('Determined the number of complete cases per variable.', verbose)
+  }
   
   collectionVarMetadata <- veupathUtils::findCollectionVariableMetadata(variables)
   isFacetCollection <- ifelse(is.null(collectionVarMetadata), FALSE, ifelse(collectionVarMetadata@plotReference@value %in% c('facet1', 'facet2'), TRUE, FALSE))
@@ -122,28 +127,30 @@ newPlotdata <- function(.dt = data.table(),
     }
 
     # Calculate complete cases *before* reshaping the data
-    # only count rows where we have at least one value in one of the collection var member columns
-    completeCasesPerCollectionCol <- lapply(collectionVarMemberColNames, function(collectionVarMember) {return(complete.cases(.dt[, ..collectionVarMember]))})
-    collectionVarDataRows <- Reduce("+", completeCasesPerCollectionCol) > 0  # Any row with val=0 means that row was missing for all vars in the collection and should be removed from the count
-    # Columns not corresponding to a collection var are treated differently. Calculate their complete cases as normal
-    nonCollectionVarColNames <- setdiff(c(x,y,z,group, panel), collectionVarMemberColNames)
-    if (length(nonCollectionVarColNames) > 0) {
-      nonCollectionVarDataRows <- complete.cases(.dt[, ..nonCollectionVarColNames])
-      # Count the rows that we keep from the collection var complete cases *and* non-collection var complete cases
-      completeCasesAllVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows*nonCollectionVarDataRows,]))
-    } else {
-      # If nonCollectionVarColNames is empty, it will interfere with the multiplication above and return 0 for complete cases always.
-      # Instead, here we only use the collection vars to calculate the complete cases
-      completeCasesAllVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows]))
-    }
+    if (completeCases) {
+      # only count rows where we have at least one value in one of the collection var member columns
+      completeCasesPerCollectionCol <- lapply(collectionVarMemberColNames, function(collectionVarMember) {return(complete.cases(.dt[, ..collectionVarMember]))})
+      collectionVarDataRows <- Reduce("+", completeCasesPerCollectionCol) > 0  # Any row with val=0 means that row was missing for all vars in the collection and should be removed from the count
+      # Columns not corresponding to a collection var are treated differently. Calculate their complete cases as normal
+      nonCollectionVarColNames <- setdiff(c(x,y,z,group, panel), collectionVarMemberColNames)
+      if (length(nonCollectionVarColNames) > 0) {
+        nonCollectionVarDataRows <- complete.cases(.dt[, ..nonCollectionVarColNames])
+        # Count the rows that we keep from the collection var complete cases *and* non-collection var complete cases
+        completeCasesAllVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows*nonCollectionVarDataRows,]))
+      } else {
+        # If nonCollectionVarColNames is empty, it will interfere with the multiplication above and return 0 for complete cases always.
+        # Instead, here we only use the collection vars to calculate the complete cases
+        completeCasesAllVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows]))
+      }
 
-    if (collectionVarMetadata@plotReference@value == 'xAxis') {
-      # Since we force the collection value to be the y variable, the whole collection includes x and y.
-      completeCasesAxesVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows,]))
-    } else {
-      # Count rows with data for x and at least 1 collection variable (remember, collection values always map to y)
-      axisDataRows <- complete.cases(.dt[, ..x]) * collectionVarDataRows
-      completeCasesAxesVars <- jsonlite::unbox(nrow(.dt[axisDataRows,]))
+      if (collectionVarMetadata@plotReference@value == 'xAxis') {
+        # Since we force the collection value to be the y variable, the whole collection includes x and y.
+        completeCasesAxesVars <- jsonlite::unbox(nrow(.dt[collectionVarDataRows,]))
+      } else {
+        # Count rows with data for x and at least 1 collection variable (remember, collection values always map to y)
+        axisDataRows <- complete.cases(.dt[, ..x]) * collectionVarDataRows
+        completeCasesAxesVars <- jsonlite::unbox(nrow(.dt[axisDataRows,]))
+      }
     }
 
     # Reshape data
@@ -196,12 +203,14 @@ newPlotdata <- function(.dt = data.table(),
   veupathUtils::logWithTime('Base data types updated for all columns as necessary.', verbose)
 
   # TODO review logic here around complete cases on the panel column
-  if (!exists('completeCasesAllVars')) {
+  if (!exists('completeCasesAllVars') && completeCases) {
     completeCasesAllVars <- complete.cases(.dt[, c(x,y,z,group,panel,geo), with=FALSE])
     completeCasesAllVars <- jsonlite::unbox(nrow(.dt[completeCasesAllVars,]))
   }
-  if (!exists('completeCasesAxesVars')) completeCasesAxesVars <- jsonlite::unbox(nrow(.dt[complete.cases(.dt[, c(x,y), with=FALSE]),]))
-  veupathUtils::logWithTime('Determined total number of complete cases across axes and strata vars.', verbose)
+  if (!exists('completeCasesAxesVars') && completeCases) {
+    completeCasesAxesVars <- jsonlite::unbox(nrow(.dt[complete.cases(.dt[, c(x,y), with=FALSE]),]))
+    veupathUtils::logWithTime('Determined total number of complete cases across axes and strata vars.', verbose)
+  }
 
   if (isEvil) {
     # Assign NA strata values to 'No data', with the exception of continuous overlays which should stay numeric
@@ -226,15 +235,17 @@ newPlotdata <- function(.dt = data.table(),
   # If using a gradient colorscale, overlay var does not contribute to final groups
   overlayGroup <- if (useGradientColorscale) NULL else group
 
-  if (xShape != 'CONTINUOUS' || uniqueN(.dt[[x]]) < 9) {
-    .dt$dummy <- 1
-    sampleSizeTable <- groupSize(.dt, x=x, y="dummy", overlayGroup, panel, geo, collapse=F)
-    .dt$dummy <- NULL
-  } else {
-    sampleSizeTable <- groupSize(.dt, x=NULL, y=x, overlayGroup, panel, geo, collapse=F)
+  # Calculate sample sizes if requested
+  if (sampleSizes) {
+    if (xShape != 'CONTINUOUS' || uniqueN(.dt[[x]]) < 9) {
+      .dt$dummy <- 1
+      sampleSizeTable <- groupSize(.dt, x=x, y="dummy", overlayGroup, panel, geo, collapse=F)
+      .dt$dummy <- NULL
+    } else {
+      sampleSizeTable <- groupSize(.dt, x=NULL, y=x, overlayGroup, panel, geo, collapse=F)
+    }
+    veupathUtils::logWithTime('Calculated sample sizes per group.', verbose)
   }
-
-  veupathUtils::logWithTime('Calculated sample sizes per group.', verbose)
 
   if (is.null(xType)) {
     index <- findVariableIndexByPlotRef(variables, 'xAxis')
@@ -249,10 +260,12 @@ newPlotdata <- function(.dt = data.table(),
 
   attr <- attributes(.dt)
   attr$variables <- variables
-  attr$completeCasesAllVars <- completeCasesAllVars
-  attr$completeCasesAxesVars <- completeCasesAxesVars
-  attr$completeCasesTable <- completeCasesTable
-  attr$sampleSizeTable <- collapseByGroup(sampleSizeTable, overlayGroup, panel, geo)
+  if (completeCases) {
+    attr$completeCasesAllVars <- completeCasesAllVars
+    attr$completeCasesAxesVars <- completeCasesAxesVars
+    attr$completeCasesTable <- completeCasesTable
+  }
+  if (sampleSizes) attr$sampleSizeTable <- collapseByGroup(sampleSizeTable, overlayGroup, panel, geo)
   attr$class = c(class, 'plot.data', attr$class)
 
   veupathUtils::setAttrFromList(.dt, attr)

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -240,7 +240,12 @@ getJSON <- function(.pd, evilMode) {
 
   names(outList)[1] <- class
   outJson <- jsonlite::toJSON(outList, na='null')
-  outJson <- gsub('"config":{', paste0('"config":{"variables":', veupathUtils::toJSON(variables, named = FALSE), ","), outJson, fixed = TRUE)
+  # Below we insert the variables into the config. The config may otherwise be empty, and if it is
+  # we do not need a comma after 'variables'.
+  outJson <- ifelse(!!length(names(namedAttrList)),
+                          gsub('"config":{', paste0('"config":{"variables":', veupathUtils::toJSON(variables, named = FALSE), ","), outJson, fixed = TRUE),
+                          gsub('"config":{', paste0('"config":{"variables":', veupathUtils::toJSON(variables, named = FALSE)), outJson, fixed = TRUE)
+  )
 
   return(outJson)
 }

--- a/tests/testthat/test-bar.R
+++ b/tests/testthat/test-bar.R
@@ -85,6 +85,14 @@ test_that("bar.dt() returns a valid plot.data barplot object", {
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(names(sampleSizes), c('panel','entity.cat6','size'))
   expect_equal(nrow(sampleSizes), 12)
+
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- bar.dt(df, variables, value='count', sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'plot.data')
+  expect_is(dt, 'barplot')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList),c('variables'))
+
 })
 
 
@@ -127,15 +135,6 @@ test_that("bar.dt() returns plot data and config of the appropriate types", {
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(class(unlist(sampleSizes$panel)), 'character')
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
-
-  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
-  dt <- bar.dt(df, variables, value='count', sampleSizes = FALSE, completeCases = FALSE)
-  expect_is(dt$label, 'list')
-  expect_equal(class(unlist(dt$label)), 'character')
-  expect_is(dt$value, 'list')
-  expect_equal(class(unlist(dt$value)), 'integer')
-  namedAttrList <- getPDAttributes(dt)
-  expect_equal(names(namedAttrList), c('variables'))
 
 
   # With numeric x

--- a/tests/testthat/test-bar.R
+++ b/tests/testthat/test-bar.R
@@ -128,6 +128,16 @@ test_that("bar.dt() returns plot data and config of the appropriate types", {
   expect_equal(class(unlist(sampleSizes$panel)), 'character')
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
 
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- bar.dt(df, variables, value='count', sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt$label, 'list')
+  expect_equal(class(unlist(dt$label)), 'character')
+  expect_is(dt$value, 'list')
+  expect_equal(class(unlist(dt$value)), 'integer')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList), c('variables'))
+
+
   # With numeric x
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
@@ -580,6 +590,19 @@ test_that("bar() returns appropriately formatted json", {
   expect_equal(class(jsonList$sampleSizeTable$overlayVariableDetails$value), 'character')
   expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
   expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
+
+  # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
+  dt <- bar.dt(df, variables, value='count', sampleSizes = FALSE, completeCases = FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList), c('barplot'))
+  expect_equal(names(jsonList$barplot$data$overlayVariableDetails), c('variableId','entityId','value','displayLabel'))
+  expect_equal(names(jsonList$barplot$data$facetVariableDetails[[1]]), c('variableId','entityId','value','displayLabel'))
+  expect_equal(jsonList$barplot$data$facetVariableDetails[[1]]$variableId, 'cat5')
+  expect_equal(names(jsonList$barplot$config), c('variables'))
+  expect_equal(names(jsonList$barplot$config$variables$variableSpec), c('variableId','entityId'))
+  expect_equal(jsonList$barplot$config$variables$variableSpec$variableId, c('cat4','cat6','cat5'))
+
   
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",

--- a/tests/testthat/test-beeswarm.R
+++ b/tests/testthat/test-beeswarm.R
@@ -51,6 +51,17 @@ test_that("beeswarm.dt() returns a valid plot.data beeswarm object", {
   expect_equal(dt$entity.cat3[[1]], 'cat3_a')
   expect_equal(dt$label[[1]], c('cat4_a','cat4_b','cat4_c','cat4_d'))
   expect_equal(unlist(lapply(dt$rawData[[1]], length)), c(42,42,29,51))
+
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- beeswarm.dt(df, variables, 0.1, FALSE, sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'plot.data')
+  expect_is(dt, 'beeswarm')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList),c('variables'))
+  expect_equal(dt$entity.cat3[[1]], 'cat3_a')
+  expect_equal(dt$label[[1]], c('cat4_a','cat4_b','cat4_c','cat4_d'))
+  expect_equal(unlist(lapply(dt$rawData[[1]], length)), c(42,42,29,51))
+  
 })
 
 test_that("beeswarm.dt() returns plot data and config of the appropriate types", {
@@ -90,13 +101,6 @@ test_that("beeswarm.dt() returns plot data and config of the appropriate types",
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(class(unlist(sampleSizes$entity.cat5)), 'character')
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
-
-
-  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
-  dt <- beeswarm.dt(df, variables, 0.2, TRUE, sampleSizes = FALSE, completeCases = FALSE)
-  expect_equal(class(dt$median[[1]]), 'numeric')
-  namedAttrList <- getPDAttributes(dt)
-  expect_equal(names(namedAttrList), c('variables'))
 
 
   #single group

--- a/tests/testthat/test-beeswarm.R
+++ b/tests/testthat/test-beeswarm.R
@@ -92,6 +92,13 @@ test_that("beeswarm.dt() returns plot data and config of the appropriate types",
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
 
 
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- beeswarm.dt(df, variables, 0.2, TRUE, sampleSizes = FALSE, completeCases = FALSE)
+  expect_equal(class(dt$median[[1]]), 'numeric')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList), c('variables'))
+
+
   #single group
   
   variables <- new("VariableMetadataList", SimpleList(
@@ -756,6 +763,19 @@ test_that("beeswarm() returns appropriately formatted json", {
   expect_equal(class(jsonList$sampleSizeTable$xVariableDetails$value[[1]]), 'character')
   expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+
+
+  # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
+  dt <- beeswarm.dt(df, variables, 0.2, FALSE, sampleSizes = FALSE, completeCases = FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList), c('beeswarm'))
+  expect_equal(names(jsonList$beeswarm), c('data','config'))
+  expect_equal(names(jsonList$beeswarm$data), c('label','rawData', 'jitteredValues'))
+  expect_equal(class(jsonList$beeswarm$data$label[[1]]), 'character')
+  expect_equal(names(jsonList$beeswarm$config), c('variables'))
+  expect_equal(names(jsonList$beeswarm$config$variables$variableSpec), c('variableId','entityId'))
+
   
   # Multiple vars for x and computed variable metadata
   variables <- new("VariableMetadataList", SimpleList(

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -173,6 +173,18 @@ test_that("box.dt() returns a valid plot.data box object", {
   expect_equal(dt$entity.cat3[[1]], 'cat3_a')
   expect_equal(dt$label[[1]], c('cat4_a','cat4_b','cat4_c','cat4_d'))
   expect_equal(unlist(lapply(dt$rawData[[1]], length)), c(42,42,29,51))
+
+
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+    dt <- box.dt(df, variables, 'all', FALSE, computeStats = T, sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'plot.data')
+  expect_is(dt, 'boxplot')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList),c('variables','statsTable'))
+  expect_equal(names(namedAttrList$statsTable), c('entity.cat4','statistic','pvalue','parameter','method','statsError'))
+  expect_equal(dt$entity.cat3[[1]], 'cat3_a')
+  expect_equal(dt$label[[1]], c('cat4_a','cat4_b','cat4_c','cat4_d'))
+  expect_equal(unlist(lapply(dt$rawData[[1]], length)), c(42,42,29,51))
 })
 
 test_that("box.dt() returns plot data and config of the appropriate types", {
@@ -246,23 +258,6 @@ test_that("box.dt() returns plot data and config of the appropriate types", {
   expect_equal(class(unlist(sampleSizes$entity.cat5)), 'character')
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
 
-  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
-  dt <- box.dt(df, variables, 'outliers', TRUE, sampleSizes = FALSE, completeCases = FALSE)
-  expect_equal(class(dt$label[[1]]), 'character')
-  expect_equal(class(dt$min[[1]]), 'numeric')
-  expect_equal(class(dt$q1[[1]]), 'numeric')
-  expect_equal(class(dt$median[[1]]), 'numeric')
-  expect_equal(class(dt$q3[[1]]), 'numeric')
-  expect_equal(class(dt$max[[1]]), 'numeric')
-  expect_equal(class(dt$lowerfence[[1]]), 'numeric')
-  expect_equal(class(dt$upperfence[[1]]), 'numeric')
-  expect_equal(class(dt$mean[[1]]), 'numeric')
-  #first group has no outliers, want json like [] rather than {}
-  expect_equal(class(dt$outliers[[1]][[1]]), 'list')
-  expect_equal(class(dt$outliers[[1]][[3]]), 'numeric')
-  namedAttrList <- getPDAttributes(dt)
-  expect_equal(names(namedAttrList), c('variables'))
-  
 
   #single group
   variables <- new("VariableMetadataList", SimpleList(
@@ -970,7 +965,7 @@ test_that("box() returns appropriately formatted json", {
   expect_equal(class(jsonList$boxplot$data$label[[1]]), 'character')
 
   # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
-  # Make sure to also ask for the stats table to ensure all goes well with this special box-specific table
+  # Make sure to also ask for the stats table to check that all goes well with this special box-specific table
   dt <- box.dt(df, variables, 'none', FALSE, computeStats = T, sampleSizes = FALSE, completeCases = FALSE)
   outJson <- getJSON(dt, FALSE)
   jsonList <- jsonlite::fromJSON(outJson)
@@ -1188,21 +1183,6 @@ test_that("box() returns appropriately formatted json", {
   dt <- box.dt(df, variables, 'none', FALSE, computeStats = T)
   outJson <- getJSON(dt, FALSE)
   jsonList <- jsonlite::fromJSON(outJson)
-  expect_equal(names(jsonList$statsTable), c('statistic','pvalue','parameter','method','statsError'))
-  expect_equal(class(jsonList$statsTable$statistic), 'numeric')
-  expect_equal(length(jsonList$statsTable$statistic), 1)
-  expect_equal(class(jsonList$statsTable$statsError), 'character')
-
-  # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
-  dt <- box.dt(df, variables, 'none', FALSE, computeStats = T, sampleSizes = FALSE, completeCases = FALSE)
-  outJson <- getJSON(dt, FALSE)
-  jsonList <- jsonlite::fromJSON(outJson)
-  expect_equal(names(jsonList), c('boxplot','statsTable'))
-  expect_equal(names(jsonList$boxplot), c('data','config'))
-  expect_equal(names(jsonList$boxplot$data), c('label','min','q1','median','q3','max','lowerfence','upperfence'))
-  expect_equal(class(jsonList$boxplot$data$label[[1]]), 'character')
-  expect_equal(names(jsonList$boxplot$config), c('variables'))
-  expect_equal(names(jsonList$boxplot$config$variables$variableSpec), c('variableId','entityId'))
   expect_equal(names(jsonList$statsTable), c('statistic','pvalue','parameter','method','statsError'))
   expect_equal(class(jsonList$statsTable$statistic), 'numeric')
   expect_equal(length(jsonList$statsTable$statistic), 1)

--- a/tests/testthat/test-histogram.R
+++ b/tests/testthat/test-histogram.R
@@ -1006,7 +1006,7 @@ test_that("histogram() returns appropriately formatted json", {
 
 
   # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
-    dt <- histogram.dt(df, variables, binWidth = NULL, value='count', barmode = 'stack', binReportValue, viewport, sampleSizes = FALSE, completeCases = FALSE)
+  dt <- histogram.dt(df, variables, binWidth = NULL, value='count', barmode = 'stack', binReportValue, viewport, sampleSizes = FALSE, completeCases = FALSE)
   outJson <- getJSON(dt, FALSE)
   jsonList <- jsonlite::fromJSON(outJson)
   expect_equal(names(jsonList),c('histogram'))

--- a/tests/testthat/test-histogram.R
+++ b/tests/testthat/test-histogram.R
@@ -247,6 +247,22 @@ test_that("histogram.dt() returns a valid plot.data histogram object", {
   # expect_true(all(grepl('T00:00:00', unlist(dt$binStart))))
   # expect_true(all(grepl('T00:00:00', unlist(dt$binEnd))))
   # expect_true(!any(grepl('T00:00:00', unlist(dt$binLabel))))
+
+
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- histogram.dt(df, variables, binWidth = 'month', value='count', barmode = 'overlay', binReportValue, viewport, sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'plot.data')
+  expect_is(dt, 'histogram')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList),c('variables','summary', 'viewport', 'binSpec', 'binSlider'))
+  expect_equal(names(namedAttrList$summary), c('min','q1','median','mean','q3','max'))
+  expect_equal(names(viewport(dt)), c('xMin','xMax'))
+  expect_equal(names(binSlider(dt)), c('min','max','step'))
+  expect_equal(names(namedAttrList$binSpec), c('type','value','units'))
+  expect_equal(as.numeric(namedAttrList$binSpec$value),1)
+  expect_equal(as.character(namedAttrList$binSpec$type),'binWidth')
+  expect_equal(as.character(namedAttrList$binSpec$unit),'month')
+  
 })
 
 test_that("histogram.dt() returns plot data and config of the appropriate types", {
@@ -987,6 +1003,20 @@ test_that("histogram() returns appropriately formatted json", {
   expect_equal(names(jsonList$histogram$config$variables$variableSpec),c('variableId','entityId'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId', 'entityId', 'displayLabel'))
   expect_equal(class(jsonList$sampleSizeTable$facetVariableDetails[[1]]$value), 'character')
+
+
+  # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
+    dt <- histogram.dt(df, variables, binWidth = NULL, value='count', barmode = 'stack', binReportValue, viewport, sampleSizes = FALSE, completeCases = FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList),c('histogram'))
+  expect_equal(names(jsonList$histogram),c('data','config'))
+  expect_equal(names(jsonList$histogram$data),c('facetVariableDetails','binLabel','value','binStart','binEnd'))
+  expect_equal(names(jsonList$histogram$config),c('variables','summary','viewport','binSpec','binSlider'))
+  expect_equal(names(jsonList$histogram$config$variables$variableSpec),c('variableId','entityId'))
+  expect_equal(names(jsonList$histogram$config$viewport),c('xMin','xMax'))
+  expect_equal(names(jsonList$histogram$config$binSlider),c('min','max','step'))
+  expect_equal(names(jsonList$histogram$config$summary),c('min','q1','median','mean','q3','max'))
 
 
   # With continuous overlay (< 9 values)

--- a/tests/testthat/test-line.R
+++ b/tests/testthat/test-line.R
@@ -84,6 +84,19 @@ test_that("lineplot.dt() returns a valid plot.data lineplot object", {
   expect_equal(nrow(sampleSizes), 12)
   expect_equal(names(viewport(dt)), c('xMin','xMax'))
   expect_equal(names(binSlider(dt)), c('min','max','step'))
+
+
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- lineplot.dt(df, variables, binWidth = NULL, value = 'mean', viewport = NULL, sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'plot.data')
+  expect_is(dt, 'lineplot')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList),c('variables',
+                                      'viewport',
+                                      'binSlider',
+                                      'binSpec'))
+  expect_equal(names(viewport(dt)), c('xMin','xMax'))
+  expect_equal(names(binSlider(dt)), c('min','max','step'))
 })
 
 test_that("lineplot.dt() returns plot data and config of the appropriate types", {
@@ -1341,6 +1354,27 @@ test_that("lineplot() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('repeatedDateA', 'contB', 'cat3', 'cat4'))
+
+
+  # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
+  dt <- lineplot.dt(df, variables, value = 'mean', binWidth=0, sampleSizes = FALSE, completeCases = FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+
+  expect_equal(names(jsonList),c('lineplot'))
+  expect_equal(names(jsonList$lineplot),c('data','config'))
+  expect_equal(names(jsonList$lineplot$data),c('overlayVariableDetails','facetVariableDetails','seriesX','seriesY', 'binSampleSize', 'errorBars'))
+  expect_equal(names(jsonList$lineplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value'))
+  expect_equal(length(jsonList$lineplot$data$facetVariableDetails), 12)
+  expect_equal(jsonList$lineplot$data$facetVariableDetails[[1]]$variableId, 'cat4')
+  expect_equal(names(jsonList$lineplot$data$binSampleSize[[1]]),"N")
+  expect_equal(names(jsonList$lineplot$data$errorBars[[1]]), c('lowerBound', 'upperBound', 'error'))
+  expect_equal(names(jsonList$lineplot$config),c('variables','viewport','binSlider','binSpec'))
+  expect_equal(names(jsonList$lineplot$config$variables$variableSpec),c('variableId','entityId'))
+  expect_equal(jsonList$lineplot$config$variables$variableSpec$variableId, c('cat4','cat3','contB','repeatedDateA'))
+  expect_equal(names(jsonList$lineplot$config$viewport),c('xMin','xMax'))
+  expect_equal(names(jsonList$lineplot$config$binSlider),c('min','max','step'))
+
 
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",

--- a/tests/testthat/test-map-markers.R
+++ b/tests/testthat/test-map-markers.R
@@ -63,6 +63,14 @@ test_that("mapMarkers.dt() returns a valid plot.data mapMarkers object", {
   expect_equal(names(sampleSizes), c('entity.cat4','entity.cat6','size'))
   expect_equal(nrow(sampleSizes), 4)
 
+
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- mapMarkers.dt(df, variables, value='count', sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'plot.data')
+  expect_is(dt, 'mapMarkers')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList),c('variables','viewport','rankedValues','overlayValues'))
+
 })
 
 
@@ -311,6 +319,24 @@ test_that("mapMarkers() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable), c('variableDetails','completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('int11', 'cat5'))
+
+
+  # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
+  dt <- mapMarkers.dt(df, variables, value='count', sampleSizes = FALSE, completeCases = FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  expect_equal(names(jsonList), c('mapMarkers'))
+  expect_equal(names(jsonList$mapMarkers), c('data','config'))
+  expect_equal(names(jsonList$mapMarkers$data), c('geoAggregateVariableDetails','label','value'))
+  expect_equal(names(jsonList$mapMarkers$config), c('variables','viewport','rankedValues','overlayValues'))
+  expect_equal(jsonList$mapMarkers$config$rankedValues, c('5','3','9','8','10','2','6','Other'))
+  expect_equal(class(jsonList$mapMarkers$config$rankedValues), 'character')
+  expect_equal(jsonList$mapMarkers$config$overlayValues, c('2','3','5','6','8','9','10','Other'))
+  expect_equal(class(jsonList$mapMarkers$config$overlayValues), 'character')
+  expect_equal(names(jsonList$mapMarkers$config$variables$variableSpec), c('variableId','entityId'))
+  expect_equal(class(unlist(jsonList$mapMarkers$config$viewport)), 'NULL')
+  expect_equal(jsonList$mapMarkers$config$variables$variableSpec$variableId, c('cat5','int11'))
+  
 
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",

--- a/tests/testthat/test-mosaic.R
+++ b/tests/testthat/test-mosaic.R
@@ -182,6 +182,15 @@ test_that("mosaic.dt() returns a valid plot.data mosaic object", {
   expect_equal(names(sampleSizes), c('entity.cat4','entity.cat7','size'))
   expect_equal(nrow(sampleSizes), 4)
   expect_equal(names(namedAttrList$statsTable), c('chisq','pvalue', 'degreesFreedom','entity.cat4'))
+
+
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- mosaic.dt(df, variables, sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'plot.data')
+  expect_is(dt, 'mosaic')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList),c('variables','statsTable'))
+  expect_equal(names(namedAttrList$statsTable), c('chisq','pvalue', 'degreesFreedom','entity.cat4'))
 })
 
 test_that("mosaic.dt() returns plot data and config of the appropriate types", {
@@ -825,6 +834,20 @@ test_that("mosaic() returns appropriately formatted json", {
   expect_equal(names(jsonList$statsTable),c('chisq','pvalue','degreesFreedom'))
   expect_equal(names(jsonList$completeCasesTable), c('variableDetails', 'completeCases'))
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+
+
+  # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
+  dt <- mosaic.dt(df, variables, sampleSizes = FALSE, completeCases = FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  
+  expect_equal(names(jsonList),c('mosaic','statsTable'))
+  expect_equal(names(jsonList$mosaic),c('data','config'))
+  expect_equal(names(jsonList$mosaic$data),c('xLabel','yLabel','value'))
+  expect_equal(names(jsonList$mosaic$config),c('variables'))
+  expect_equal(names(jsonList$mosaic$config$variables$variableSpec),c('variableId','entityId'))
+  expect_equal(jsonList$mosaic$config$variables$variableSpec$variableId, c('int6','int7'))
+  expect_equal(names(jsonList$statsTable),c('chisq','pvalue','degreesFreedom'))
 
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -217,6 +217,22 @@ test_that("scattergl.dt() returns plot data and config of the appropriate types"
   expect_equal(class(unlist(sampleSizes$entity.cat4)), 'character')
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
 
+
+  ## Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- scattergl.dt(df, variables, 'raw', sampleSizes = FALSE, completeCases = FALSE)
+  expect_equal(class(unlist(dt$entity.cat4)), 'character')
+  expect_equal(class(unlist(dt$entity.cat3)), 'character')
+  expect_equal(class(unlist(dt$seriesX)), 'character')
+  expect_equal(class(unlist(dt$seriesY)), 'character')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList), c('variables'))
+  # expect_equal(class(namedAttrList$completeCasesAllVars),NULL)
+  # expect_equal(class(namedAttrList$completeCasesAxesVars),NULL)
+  # completeCases <- completeCasesTable(dt)
+  # expect_equal(completeCases, NULL)
+  # sampleSizes <- sampleSizeTable(dt)
+  # expect_equal(sampleSizes, NULL)
+
 })
 
 test_that("scattergl.dt() returns an appropriately sized data.table", { 

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -226,12 +226,6 @@ test_that("scattergl.dt() returns plot data and config of the appropriate types"
   expect_equal(class(unlist(dt$seriesY)), 'character')
   namedAttrList <- getPDAttributes(dt)
   expect_equal(names(namedAttrList), c('variables'))
-  # expect_equal(class(namedAttrList$completeCasesAllVars),NULL)
-  # expect_equal(class(namedAttrList$completeCasesAxesVars),NULL)
-  # completeCases <- completeCasesTable(dt)
-  # expect_equal(completeCases, NULL)
-  # sampleSizes <- sampleSizeTable(dt)
-  # expect_equal(sampleSizes, NULL)
 
 })
 
@@ -664,7 +658,17 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(dt$panel[1], 'cat3_a.||.contA')
   expect_equal(veupathUtils::findVariableSpecFromPlotRef(attr(dt, 'variables'), 'facet2')@variableId, 'collection')
   expect_equal(veupathUtils::findVariableSpecFromPlotRef(attr(dt, 'variables'), 'yAxis')@variableId, 'collectionVarValues')
-  
+
+  dt <- scattergl.dt(df, variables, 'raw', sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'data.table')
+  expect_equal(nrow(dt), 9)
+  expect_equal(names(dt), c('panel', 'seriesX', 'seriesY'))
+  expect_equal(dt$panel[1], 'cat3_a.||.contA')
+  expect_equal(veupathUtils::findVariableSpecFromPlotRef(attr(dt, 'variables'), 'facet2')@variableId, 'collection')
+  expect_equal(veupathUtils::findVariableSpecFromPlotRef(attr(dt, 'variables'), 'yAxis')@variableId, 'collectionVarValues')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList), c('variables'))
+
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
       variableClass = new("VariableClass", value = 'computed'),

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -218,7 +218,7 @@ test_that("scattergl.dt() returns plot data and config of the appropriate types"
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
 
 
-  ## Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
   dt <- scattergl.dt(df, variables, 'raw', sampleSizes = FALSE, completeCases = FALSE)
   expect_equal(class(unlist(dt$entity.cat4)), 'character')
   expect_equal(class(unlist(dt$entity.cat3)), 'character')
@@ -658,16 +658,6 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(dt$panel[1], 'cat3_a.||.contA')
   expect_equal(veupathUtils::findVariableSpecFromPlotRef(attr(dt, 'variables'), 'facet2')@variableId, 'collection')
   expect_equal(veupathUtils::findVariableSpecFromPlotRef(attr(dt, 'variables'), 'yAxis')@variableId, 'collectionVarValues')
-
-  dt <- scattergl.dt(df, variables, 'raw', sampleSizes = FALSE, completeCases = FALSE)
-  expect_is(dt, 'data.table')
-  expect_equal(nrow(dt), 9)
-  expect_equal(names(dt), c('panel', 'seriesX', 'seriesY'))
-  expect_equal(dt$panel[1], 'cat3_a.||.contA')
-  expect_equal(veupathUtils::findVariableSpecFromPlotRef(attr(dt, 'variables'), 'facet2')@variableId, 'collection')
-  expect_equal(veupathUtils::findVariableSpecFromPlotRef(attr(dt, 'variables'), 'yAxis')@variableId, 'collectionVarValues')
-  namedAttrList <- getPDAttributes(dt)
-  expect_equal(names(namedAttrList), c('variables'))
 
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
@@ -1117,6 +1107,19 @@ test_that("scattergl() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(length(jsonList$completeCasesTable$variableDetails$variableId), 5)
   
+  # Ensure sampleSizeTable and completeCasesTable are not part of json if we do not ask for them.
+  dt <- scattergl.dt(df, variables, 'raw', sampleSizes = FALSE, completeCases = FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  
+  expect_equal(names(jsonList),c('scatterplot'))
+  expect_equal(names(jsonList$scatterplot),c('data','config'))
+  expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','seriesX','seriesY'))
+  expect_equal(names(jsonList$scatterplot$data$facetVariableDetails[[1]]),c('variableId','entityId','value','displayLabel'))
+  expect_equal(names(jsonList$scatterplot$config),c('variables'))
+  
+
+
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
       variableClass = new("VariableClass", value = 'native'),

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -121,6 +121,14 @@ test_that("scattergl.dt() returns a valid plot.data scatter object", {
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(names(sampleSizes), c('entity.cat3','entity.cat4','size'))
   expect_equal(nrow(sampleSizes), 12)
+
+  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
+  dt <- scattergl.dt(df, variables, 'raw', sampleSizes = FALSE, completeCases = FALSE)
+  expect_is(dt, 'plot.data')
+  expect_is(dt, 'scatterplot')
+  namedAttrList <- getPDAttributes(dt)
+  expect_equal(names(namedAttrList),c('variables'))
+
 })
 
 test_that("scattergl.dt() returns plot data and config of the appropriate types", {
@@ -216,16 +224,6 @@ test_that("scattergl.dt() returns plot data and config of the appropriate types"
   sampleSizes <- sampleSizeTable(dt)
   expect_equal(class(unlist(sampleSizes$entity.cat4)), 'character')
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
-
-
-  # Ensure sampleSizeTable and completeCasesTable do not get returned if we do not ask for them.
-  dt <- scattergl.dt(df, variables, 'raw', sampleSizes = FALSE, completeCases = FALSE)
-  expect_equal(class(unlist(dt$entity.cat4)), 'character')
-  expect_equal(class(unlist(dt$entity.cat3)), 'character')
-  expect_equal(class(unlist(dt$seriesX)), 'character')
-  expect_equal(class(unlist(dt$seriesY)), 'character')
-  namedAttrList <- getPDAttributes(dt)
-  expect_equal(names(namedAttrList), c('variables'))
 
 })
 


### PR DESCRIPTION
Resolves #209 

Adds a boolean argument to all plot types that determines whether or not to compute and return sample size and complete cases information.

Note there was some json wrangling, but all is looking good now. Otherwise this is mostly straightforward. 

