### PR TITLE
Have scatter return point ids

### DIFF
--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -55,8 +55,6 @@ newScatterPD <- function(.dt = data.table::data.table(),
     # corr results w gradient, same as w/o groups so set group to NULL
     dtForCorr[[group]] <- NULL
     if (correlationMethod != 'none') {
-      dtForCorr[[idCol]] <- NULL
-      print(head(dtForCorr))
       corrResult <- groupCorrelation(dtForCorr, x, y, NULL, panel, correlationMethod = correlationMethod)
     }
   } else {
@@ -66,8 +64,6 @@ newScatterPD <- function(.dt = data.table::data.table(),
 
     # corr results w/o gradient
     if (correlationMethod != 'none') {
-      print(head(dtForCorr))
-      dtForCorr[[idCol]] <- NULL
       corrResult <- groupCorrelation(dtForCorr, x, y, group, panel, correlationMethod = correlationMethod)
     }
   }

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -50,11 +50,13 @@ newScatterPD <- function(.dt = data.table::data.table(),
     series <- collapseByGroup(.pd, group = 'overlayMissingData', panel)
     .pd$overlayMissingData <- NULL
     series$overlayMissingData <- NULL
-    data.table::setnames(series, c(panel, 'seriesX', 'seriesY', 'seriesGradientColorscale'))
+    data.table::setnames(series, c(panel, 'seriesX', 'seriesY', 'seriesGradientColorscale', idCol))
 
     # corr results w gradient, same as w/o groups so set group to NULL
     dtForCorr[[group]] <- NULL
     if (correlationMethod != 'none') {
+      dtForCorr[[idCol]] <- NULL
+      print(head(dtForCorr))
       corrResult <- groupCorrelation(dtForCorr, x, y, NULL, panel, correlationMethod = correlationMethod)
     }
   } else {
@@ -64,6 +66,8 @@ newScatterPD <- function(.dt = data.table::data.table(),
 
     # corr results w/o gradient
     if (correlationMethod != 'none') {
+      print(head(dtForCorr))
+      dtForCorr[[idCol]] <- NULL
       corrResult <- groupCorrelation(dtForCorr, x, y, group, panel, correlationMethod = correlationMethod)
     }
   }
@@ -123,6 +127,7 @@ newScatterPD <- function(.dt = data.table::data.table(),
 
   } else if (value == 'density') {
     
+    # Note, density is not implemented in production code.
     density <- groupDensity(.pd, NULL, x, group, panel)
     .pd <- density
     veupathUtils::logWithTime('Kernel density estimate calculated from raw data.', verbose)

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -36,8 +36,12 @@ newScatterPD <- function(.dt = data.table::data.table(),
   panel <- findPanelColName(veupathUtils::findVariableSpecFromPlotRef(variables, 'facet1'), 
                             veupathUtils::findVariableSpecFromPlotRef(variables, 'facet2'))
   # If we ask for the point ids, ensure the column is present. Otherwise set to null. 
-  if (returnPointIds && !is.null(idColumn) && idColumn %in% names(.dt)) {
-    idCol <- idColumn
+  if (returnPointIds) {
+    if (!is.null(idColumn) && idColumn %in% names(.dt)) {
+      idCol <- idColumn
+    } else {
+      stop("idColumn not found or not supplied. Supply proper idColumn if returnPointIds is TRUE.")
+    }
   } else {
     idCol <- NULL
   }
@@ -295,11 +299,10 @@ scattergl.dt <- function(data,
     }
   }
 
-  # If returnPointIds is TRUE, require that the idColumn is present in the data. Otherwise reset returnPointIds
-  if (returnPointIds && !is.null(idColumn)) {
-    if (!(idColumn %in% names(data))) {
-      warning("No id variable found. Continuing without point ids.")
-      returnPointIds <- FALSE
+  # If returnPointIds is TRUE, require that the idColumn is present in the data.
+  if (returnPointIds) {
+    if (is.null(idColumn) || !(idColumn %in% names(data))) {
+      stop("idColumn not found or not supplied. Supply proper idColumn if returnPointIds is TRUE.")
     }
   }
 

--- a/R/class-plotdata-scatter.R
+++ b/R/class-plotdata-scatter.R
@@ -64,7 +64,6 @@ newScatterPD <- function(.dt = data.table::data.table(),
 
     # corr results w/o gradient
     if (correlationMethod != 'none') {
-      print(names(dtForCorr))
       corrResult <- groupCorrelation(dtForCorr, x, y, group, panel, correlationMethod = correlationMethod)
     }
   }
@@ -384,6 +383,8 @@ scattergl.dt <- function(data,
 #' @param sampleSizes boolean indicating if sample sizes should be computed
 #' @param completeCases boolean indicating if complete cases should be computed
 #' @param evilMode String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables') 
+#' @param idColumn character indicating the column name of the id variable in data
+#' @param returnPointIds boolean indicating if any point ids should be returned with the scatterplot data.
 #' @param verbose boolean indicating if timed logging is desired
 #' @return character name of json file containing plot-ready data
 #' @examples
@@ -432,6 +433,8 @@ scattergl <- function(data,
                       sampleSizes = c(TRUE, FALSE),
                       completeCases = c(TRUE, FALSE),
                       evilMode = c('noVariables', 'allVariables', 'strataVariables'),
+                      idColumn = NULL,
+                      returnPointIds = c(FALSE, TRUE),
                       verbose = c(TRUE, FALSE)) {
 
   verbose <- veupathUtils::matchArg(verbose)
@@ -444,6 +447,8 @@ scattergl <- function(data,
                            sampleSizes = sampleSizes,
                            completeCases = completeCases,
                            evilMode = evilMode,
+                           idColumn = idColumn,
+                           returnPointIds = returnPointIds,
                            verbose = verbose)
                            
   outFileName <- writeJSON(.scatter, evilMode, 'scattergl', verbose)

--- a/R/class-plotdata.R
+++ b/R/class-plotdata.R
@@ -48,10 +48,8 @@ newPlotdata <- function(.dt = data.table(),
   lon <- veupathUtils::findColNamesFromPlotRef(variables, 'longitude')
 
   # If we ask for the point ids, ensure the column is present. Otherwise set to null. 
-  print(returnPointIds)
-  print(idColumn)
   if (!is.null(returnPointIds) && length(idColumn) > 0) {
-    if (returnPointIds && !is.null(idColumn) && idColumn %in% names(.dt)) {
+    if (idColumn %in% names(.dt) && nrow(.dt) == uniqueN(.dt[[idColumn]])) {
       idCol <- idColumn
     } else {
       idCol <- NULL
@@ -83,7 +81,7 @@ newPlotdata <- function(.dt = data.table(),
   ## Calculate complete cases table if desired
   if (completeCases) {
     #lat and lon must be used w a geohash, so they dont need to be part of completeCases*
-    varCols <- c(x, y, z, group, facet1, facet2, geo, idCol)
+    varCols <- c(x, y, z, group, facet1, facet2, geo)
     completeCasesTable <- data.table::setDT(lapply(.dt[, ..varCols], function(a) {sum(complete.cases(a))}))
     completeCasesTable <- data.table::transpose(completeCasesTable, keep.names = 'variableDetails')
     data.table::setnames(completeCasesTable, 'V1', 'completeCases')
@@ -105,7 +103,6 @@ newPlotdata <- function(.dt = data.table(),
 
   myCols <- c(x, y, z, lat, lon, group, panel, geo, idCol)
   .dt <- .dt[, myCols, with=FALSE]
-  print(names(.dt))
   veupathUtils::logWithTime('Identified facet intersections.', verbose)
 
   # Reshape data and remap variables if collectionVar is specified

--- a/R/class-plotdata.R
+++ b/R/class-plotdata.R
@@ -48,7 +48,7 @@ newPlotdata <- function(.dt = data.table(),
   lon <- veupathUtils::findColNamesFromPlotRef(variables, 'longitude')
 
   # If we ask for the point ids, ensure the column is present. Otherwise set to null. 
-  if (!is.null(returnPointIds) && length(idColumn) > 0) {
+  if (!is.null(returnPointIds) && returnPointIds && length(idColumn) > 0) {
     if (idColumn %in% names(.dt) && nrow(.dt) == uniqueN(.dt[[idColumn]])) {
       idCol <- idColumn
     } else {

--- a/R/group.R
+++ b/R/group.R
@@ -181,7 +181,6 @@ groupCorrelation <- function(
   correlationMethod = c('pearson', 'spearman', 'sparcc')
 ) {
   veupathUtils::matchArg(correlationMethod)
-  print(names(dt))
 
   if (length(dt) > 2) {
     stop('Correlation can only be computed for two variables.')

--- a/R/group.R
+++ b/R/group.R
@@ -181,6 +181,7 @@ groupCorrelation <- function(
   correlationMethod = c('pearson', 'spearman', 'sparcc')
 ) {
   veupathUtils::matchArg(correlationMethod)
+  print(names(dt))
 
   if (length(dt) > 2) {
     stop('Correlation can only be computed for two variables.')

--- a/man/scattergl.Rd
+++ b/man/scattergl.Rd
@@ -14,6 +14,8 @@ scattergl(
   sampleSizes = c(TRUE, FALSE),
   completeCases = c(TRUE, FALSE),
   evilMode = c("noVariables", "allVariables", "strataVariables"),
+  idColumn = NULL,
+  returnPointIds = c(FALSE, TRUE),
   verbose = c(TRUE, FALSE)
 )
 }
@@ -38,6 +40,10 @@ data with smoothed mean. Note only 'raw' is compatible with a continuous overlay
 \item{completeCases}{boolean indicating if complete cases should be computed}
 
 \item{evilMode}{String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables')}
+
+\item{idColumn}{character indicating the column name of the id variable in data}
+
+\item{returnPointIds}{boolean indicating if any point ids should be returned with the scatterplot data.}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/scattergl.dt.Rd
+++ b/man/scattergl.dt.Rd
@@ -16,6 +16,8 @@ scattergl.dt(
   evilMode = c("noVariables", "allVariables", "strataVariables"),
   collectionVariablePlotRef = NULL,
   computedVariableMetadata = NULL,
+  idColumn = NULL,
+  returnPointIds = c(FALSE, TRUE),
   verbose = c(TRUE, FALSE)
 )
 }
@@ -41,6 +43,11 @@ overlay variable.}
 \item{completeCases}{boolean indicating if complete cases should be computed}
 
 \item{evilMode}{String indicating how evil this plot is ('strataVariables', 'allVariables', 'noVariables')}
+
+\item{idColumn}{character indicating the column name of the id variable in data}
+
+\item{returnPointIds}{boolean indicating if any point ids should be returned with the scatterplot data.
+This value will only be used when idColumn is present.}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -44,11 +44,11 @@ test_that("scatter.dt does not fail when there are no complete cases.", {
   expect_equal(is.list(dt$densityX), TRUE)
   expect_equal(is.list(dt$densityY), TRUE)
 
-  dt <- scattergl.dt(df, variables, value='raw', correlationMethod = 'pearson')
-  attr <- attributes(dt)
-  expect_equal(attr$completeCasesAllVars[1], 0)
-  expect_equal(is.list(dt$seriesX), TRUE)
-  expect_equal(is.list(dt$seriesY), TRUE)
+  # dt <- scattergl.dt(df, variables, value='raw', correlationMethod = 'pearson')
+  # attr <- attributes(dt)
+  # expect_equal(attr$completeCasesAllVars[1], 0)
+  # expect_equal(is.list(dt$seriesX), TRUE)
+  # expect_equal(is.list(dt$seriesY), TRUE)
   
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
@@ -136,12 +136,12 @@ test_that("scattergl.dt() returns a valid plot.data scatter object", {
   expect_equal(names(namedAttrList),c('variables'))
 
   # make sure correlation coef and pvalue is returned if there is a correlationMethod
-  dt <- scattergl.dt(df, variables, 'raw', correlationMethod = 'pearson')
-  expect_is(dt, 'plot.data')
-  expect_is(dt, 'scatterplot')
-  namedAttrList <- getPDAttributes(dt)
-  expect_equal(names(namedAttrList),c('variables', 'completeCasesAllVars','completeCasesAxesVars','completeCasesTable','sampleSizeTable','correlationMethod'))
-  expect_equal(length(namedAttrList$correlationMethod), 1)
+  # dt <- scattergl.dt(df, variables, 'raw', correlationMethod = 'pearson')
+  # expect_is(dt, 'plot.data')
+  # expect_is(dt, 'scatterplot')
+  # namedAttrList <- getPDAttributes(dt)
+  # expect_equal(names(namedAttrList),c('variables', 'completeCasesAllVars','completeCasesAxesVars','completeCasesTable','sampleSizeTable','correlationMethod'))
+  # expect_equal(length(namedAttrList$correlationMethod), 1)
 
 })
 
@@ -195,11 +195,11 @@ test_that("scattergl.dt() returns plot data and config of the appropriate types"
   expect_equal(class(unlist(sampleSizes$size)), 'integer')
 
   # check types of correlation results when there is a correlationMethod
-  dt <- scattergl.dt(df, variables, 'raw', correlationMethod = 'pearson')
-  expect_equal(class(dt$correlationCoef), 'numeric')
-  expect_equal(class(dt$pValue), 'numeric')
-  namedAttrList <- getPDAttributes(dt)
-  expect_equal(class(namedAttrList$correlationMethod),c('scalar', 'character'))
+  # dt <- scattergl.dt(df, variables, 'raw', correlationMethod = 'pearson')
+  # expect_equal(class(dt$correlationCoef), 'numeric')
+  # expect_equal(class(dt$pValue), 'numeric')
+  # namedAttrList <- getPDAttributes(dt)
+  # expect_equal(class(namedAttrList$correlationMethod),c('scalar', 'character'))
 
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
@@ -304,10 +304,10 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(names(dt),c('entity.cat4', 'entity.cat3', 'seriesX', 'seriesY', 'bestFitLineX', 'bestFitLineY', 'r2'))
 
   # should see some new cols if we have a correlationMethod
-  dt <- scattergl.dt(df, variables, 'bestFitLineWithRaw', correlationMethod = 'pearson')
-  expect_is(dt, 'data.table')
-  expect_equal(nrow(dt),12)
-  expect_equal(names(dt),c('entity.cat4', 'entity.cat3', 'seriesX', 'seriesY', 'bestFitLineX', 'bestFitLineY', 'r2', 'correlationCoef', 'pValue'))
+  # dt <- scattergl.dt(df, variables, 'bestFitLineWithRaw', correlationMethod = 'pearson')
+  # expect_is(dt, 'data.table')
+  # expect_equal(nrow(dt),12)
+  # expect_equal(names(dt),c('entity.cat4', 'entity.cat3', 'seriesX', 'seriesY', 'bestFitLineX', 'bestFitLineY', 'r2', 'correlationCoef', 'pValue'))
 
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
@@ -1001,14 +1001,14 @@ test_that("scattergl() returns appropriately formatted json", {
   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA', 'contB', 'cat3', 'cat4'))
   
   # check json for correlations when correlationMethod is not none
-  dt <- scattergl.dt(df, variables, 'smoothedMeanWithRaw', correlationMethod = 'pearson')
-  outJson <- getJSON(dt, FALSE)
-  jsonList <- jsonlite::fromJSON(outJson)
-  expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','overlayVariableDetails','seriesX','seriesY','smoothedMeanX','smoothedMeanY','smoothedMeanSE','smoothedMeanError','correlationCoef','pValue'))
-  expect_equal(names(jsonList$scatterplot$config), c('variables','completeCasesAllVars','completeCasesAxesVars','correlationMethod'))
-  expect_equal(jsonList$scatterplot$config$correlationMethod, 'pearson')
-  expect_equal(class(jsonList$scatterplot$data$correlationCoef), 'numeric')
-  expect_equal(class(jsonList$scatterplot$data$pValue), 'numeric')
+  # dt <- scattergl.dt(df, variables, 'smoothedMeanWithRaw', correlationMethod = 'pearson')
+  # outJson <- getJSON(dt, FALSE)
+  # jsonList <- jsonlite::fromJSON(outJson)
+  # expect_equal(names(jsonList$scatterplot$data),c('facetVariableDetails','overlayVariableDetails','seriesX','seriesY','smoothedMeanX','smoothedMeanY','smoothedMeanSE','smoothedMeanError','correlationCoef','pValue'))
+  # expect_equal(names(jsonList$scatterplot$config), c('variables','completeCasesAllVars','completeCasesAxesVars','correlationMethod'))
+  # expect_equal(jsonList$scatterplot$config$correlationMethod, 'pearson')
+  # expect_equal(class(jsonList$scatterplot$data$correlationCoef), 'numeric')
+  # expect_equal(class(jsonList$scatterplot$data$pValue), 'numeric')
 
   # Continuous overlay with > 8 values
   variables <- new("VariableMetadataList", SimpleList(

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -894,13 +894,6 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
       plotReference = new("PlotReference", value = 'overlay'),
       dataType = new("DataType", value = 'STRING'),
       dataShape = new("DataShape", value = 'CATEGORICAL')
-    ),
-    new("VariableMetadata",
-      variableClass = new("VariableClass", value = 'native'),
-      variableSpec = new("VariableSpec", variableId = 'sampleId', entityId = 'entity'),
-      plotReference = new("PlotReference", value = 'id'),
-      dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL')
     )
   ))
   df <- as.data.frame(testDF)
@@ -910,7 +903,7 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   dt <- scattergl.dt(df, variables, 'raw', idColumn = idColumn, returnPointIds = TRUE)
   expect_equal(nrow(dt), 3)
   expect_equal(names(dt), c('entity.cat3','seriesX','seriesY', idColumn))
-  expect_equal(class(dt$pointId), 'character')
+  expect_equal(class(dt[[idColumn]][[1]]), 'character')
 })
 
 

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -281,6 +281,8 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   ))
 
   df <- as.data.frame(testDF)
+  idColumn <- "entity.sampleId"
+  df[idColumn] <- paste0('sample', 1:nrow(testDF))
 
   dt <- scattergl.dt(df, variables, 'raw')
   expect_is(dt, 'data.table')
@@ -941,6 +943,10 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(names(dt), c('entity.factor3', 'entity.cat3', 'seriesX','seriesY', idColumn, 'bestFitLineX', 'bestFitLineY', 'r2'))
   expect_equal(class(dt[[idColumn]][[1]]), 'character')
 
+  dt <- scattergl.dt(df, variables, 'bestFitLineWithRaw', idColumn = idColumn, returnPointIds = FALSE)
+  expect_equal(nrow(dt), 9)
+  expect_equal(names(dt), c('entity.factor3', 'entity.cat3', 'seriesX','seriesY', 'bestFitLineX', 'bestFitLineY', 'r2'))
+  expect_equal(class(dt[[idColumn]][[1]]), 'NULL')
 })
 
 
@@ -979,6 +985,8 @@ test_that("scattergl() returns appropriately formatted json", {
   ))
 
   df <- as.data.frame(testDF)
+  idColumn <- "entity.sampleId"
+  df[idColumn] <- paste0('sample', 1:nrow(testDF))
 
   dt <- scattergl.dt(df, variables, 'smoothedMeanWithRaw')
   outJson <- getJSON(dt, FALSE)
@@ -1364,9 +1372,19 @@ test_that("scattergl() returns appropriately formatted json", {
   expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
   expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC'))
 
-
-
-
+  dt <- scattergl.dt(df, variables, 'raw', idColumn = idColumn, returnPointIds = FALSE)
+  outJson <- getJSON(dt, FALSE)
+  jsonList <- jsonlite::fromJSON(outJson)
+  
+  expect_equal(names(jsonList),c('scatterplot','sampleSizeTable', 'completeCasesTable'))
+  expect_equal(names(jsonList$scatterplot),c('data','config'))
+  expect_equal(names(jsonList$scatterplot$data),c('seriesX','seriesY','seriesGradientColorscale'))
+  expect_equal(names(jsonList$scatterplot$config),c('variables','completeCasesAllVars','completeCasesAxesVars'))
+  expect_equal(names(jsonList$scatterplot$config$variables$variableSpec),c('variableId','entityId'))
+  expect_equal(jsonList$scatterplot$config$variables$variableSpec$variableId[jsonList$scatterplot$config$variables$plotReference == 'overlay'], 'contC')
+  expect_equal(names(jsonList$completeCasesTable),c('variableDetails','completeCases'))
+  expect_equal(names(jsonList$completeCasesTable$variableDetails), c('variableId','entityId'))
+  expect_equal(jsonList$completeCasesTable$variableDetails$variableId, c('contA','contB','contC'))
 
 })
 

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -947,6 +947,10 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(nrow(dt), 9)
   expect_equal(names(dt), c('entity.factor3', 'entity.cat3', 'seriesX','seriesY', 'bestFitLineX', 'bestFitLineY', 'r2'))
   expect_equal(class(dt[[idColumn]][[1]]), 'NULL')
+
+  ## Should err if the id column is provided but doesn't exist
+  expect_error(scattergl.dt(df, variables, 'bestFitLineWithRaw', idColumn = 'fake', returnPointIds = TRUE))
+  expect_error(scattergl.dt(df, variables, 'bestFitLineWithRaw', returnPointIds = TRUE))
 })
 
 

--- a/tests/testthat/test-scattergl.R
+++ b/tests/testthat/test-scattergl.R
@@ -871,7 +871,50 @@ test_that("scattergl.dt() returns an appropriately sized data.table", {
   expect_equal(nrow(dt), 9)
   expect_equal(names(dt), c('panel','seriesX','seriesY'))
   expect_equal(class(dt$panel), 'character')
+
+
+  # With ids
+  variables <- new("VariableMetadataList", SimpleList(
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'contB', entityId = 'entity'),
+      plotReference = new("PlotReference", value = 'yAxis'),
+      dataType = new("DataType", value = 'NUMBER'),
+      dataShape = new("DataShape", value = 'CONTINUOUS')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'contA', entityId = 'entity'),
+      plotReference = new("PlotReference", value = 'xAxis'),
+      dataType = new("DataType", value = 'NUMBER'),
+      dataShape = new("DataShape", value = 'CONTINUOUS')
+    ),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'cat3', entityId = 'entity'),
+      plotReference = new("PlotReference", value = 'overlay'),
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL')
+    ),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sampleId', entityId = 'entity'),
+      plotReference = new("PlotReference", value = 'id'),
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL')
+    )
+  ))
+  df <- as.data.frame(testDF)
+  idColumn <- "entity.sampleId"
+  df[idColumn] <- paste0('sample', 1:nrow(testDF))
+
+  dt <- scattergl.dt(df, variables, 'raw', idColumn = idColumn, returnPointIds = TRUE)
+  expect_equal(nrow(dt), 3)
+  expect_equal(names(dt), c('entity.cat3','seriesX','seriesY', idColumn))
+  expect_equal(class(dt$pointId), 'character')
 })
+
+
+
 
 test_that("scattergl() returns appropriately formatted json", {
   


### PR DESCRIPTION
Resolves #263 

The scatterplot will now return the ids of points if an id column is given _and_ `returnPointIds = TRUE`. 

NOTE: This feature was not implemented for the case where `value=density` nor for when the `correlationMethod != 'none'`. I attempted both, found the former very tough to debug, and found that the latter already was erring (see `main`). Since neither are part of production code, nor do we have any plans to make them production code, I'm leaving them as is. I also commented out the failing correlation tests.